### PR TITLE
feat(provider): fetch live model list from NeuralWatt API

### DIFF
--- a/src/extensions/provider/index.ts
+++ b/src/extensions/provider/index.ts
@@ -1,4 +1,4 @@
-import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import type { ExtensionAPI, ProviderModelConfig } from "@earendil-works/pi-coding-agent";
 import {
   configLoader,
   emitConfigUpdated,
@@ -17,13 +17,17 @@ import {
 } from "../../types/quota-events";
 import { fetchQuotas } from "../../utils/quotas";
 import { normalizeNeuralwattContextOverflowError } from "./context-overflow";
-import { getNeuralwattModels } from "./models";
+import { buildModelList, fetchNeuralwattModels, getNeuralwattModels } from "./models";
 import { buildQuotasFromHeaders, fetchRequestedQuotas } from "./quota-store";
 
 const HEADER_EMIT_THROTTLE_MS = 5_000;
 
-function registerNeuralwattProvider(pi: ExtensionAPI): void {
+function registerNeuralwattProvider(
+  pi: ExtensionAPI,
+  fetchedModels?: ProviderModelConfig[],
+): void {
   const { includeLegacyModelIds } = configLoader.getConfig();
+  const baseModels = fetchedModels ?? getNeuralwattModels();
 
   pi.registerProvider("neuralwatt", {
     baseUrl: "https://api.neuralwatt.com/v1",
@@ -34,16 +38,15 @@ function registerNeuralwattProvider(pi: ExtensionAPI): void {
       Referer: "https://pi.dev",
       "X-Title": "npm:@aliou/pi-neuralwatt",
     },
-    models: getNeuralwattModels({
-      includeLegacyModelIds,
-    }),
+    models: buildModelList(baseModels, includeLegacyModelIds),
   });
 }
 
 export default async function (pi: ExtensionAPI) {
   await configLoader.load();
 
-  registerNeuralwattProvider(pi);
+  const fetchedModels = await fetchNeuralwattModels();
+  registerNeuralwattProvider(pi, fetchedModels);
 
   const loadedFeatures = new Set<NeuralwattFeatureId>();
 
@@ -53,7 +56,7 @@ export default async function (pi: ExtensionAPI) {
   });
 
   pi.events.on(NEURALWATT_CONFIG_UPDATED_EVENT, () => {
-    registerNeuralwattProvider(pi);
+    registerNeuralwattProvider(pi, fetchedModels);
   });
 
   let lastHeaderEmitAt = 0;

--- a/src/extensions/provider/models.ts
+++ b/src/extensions/provider/models.ts
@@ -283,6 +283,101 @@ const LEGACY_NEURALWATT_MODELS: ProviderModelConfig[] = Object.entries(
   };
 });
 
+interface NeuralwattApiModel {
+  id: string;
+  metadata: {
+    display_name: string | null;
+    provider: string;
+    capabilities: {
+      vision: boolean;
+      reasoning: boolean;
+      developer_role: boolean;
+    };
+    limits: {
+      max_context_length: number;
+      max_output_tokens: number | null;
+    };
+    pricing: {
+      input_per_million: number;
+      output_per_million: number;
+      cached_input_per_million: number | null;
+      cached_output_per_million: number | null;
+    };
+  };
+}
+
+export async function fetchNeuralwattModels(): Promise<ProviderModelConfig[] | undefined> {
+  try {
+    const response = await fetch("https://api.neuralwatt.com/v1/models");
+    if (!response.ok) return undefined;
+    const data = (await response.json()) as { data: NeuralwattApiModel[] };
+    if (!Array.isArray(data.data)) return undefined;
+
+    return data.data.map((model) => {
+      const md = model.metadata;
+      const reasoning = md.capabilities.reasoning;
+      const input: ("text" | "image")[] = ["text"];
+      if (md.capabilities.vision) input.push("image");
+
+      const config: ProviderModelConfig = {
+        id: model.id,
+        name: md.display_name ?? model.id,
+        reasoning,
+        input,
+        cost: {
+          input: md.pricing.input_per_million,
+          output: md.pricing.output_per_million,
+          cacheRead: md.pricing.cached_input_per_million ?? 0,
+          cacheWrite: md.pricing.cached_output_per_million ?? 0,
+        },
+        contextWindow: md.limits.max_context_length,
+        maxTokens: md.limits.max_output_tokens ?? 65536,
+        compat: {
+          supportsDeveloperRole: md.capabilities.developer_role,
+          maxTokensField: "max_tokens",
+        },
+      };
+
+      if (reasoning) {
+        config.thinkingLevelMap = {
+          minimal: null,
+          low: null,
+          medium: "medium",
+          high: null,
+          xhigh: null,
+        };
+        config.compat = {
+          ...config.compat,
+          requiresReasoningContentOnAssistantMessages: true,
+        };
+      }
+
+      return config;
+    });
+  } catch {
+    return undefined;
+  }
+}
+
+export function buildModelList(
+  models: ProviderModelConfig[],
+  includeLegacyModelIds?: boolean,
+): ProviderModelConfig[] {
+  if (!includeLegacyModelIds) return models;
+
+  const legacy: ProviderModelConfig[] = [];
+  for (const [legacyId, canonicalId] of Object.entries(LEGACY_MODEL_ALIAS_MAP)) {
+    const canonical = models.find((m) => m.id === canonicalId);
+    if (!canonical) continue;
+    legacy.push({
+      ...canonical,
+      id: legacyId,
+      name: `${canonical.name} (legacy ID)`,
+    });
+  }
+  return [...models, ...legacy];
+}
+
 export function getNeuralwattModels(options?: {
   includeLegacyModelIds?: boolean;
 }): ProviderModelConfig[] {


### PR DESCRIPTION
This PR dynamically fetches the available model list from https://api.neuralwatt.com/v1/models instead of relying on a hardcoded list.

## Changes

- **models.ts**: 
  - Added `fetchNeuralwattModels()` to query the live API and map response metadata to `ProviderModelConfig` objects (pricing, context window, vision/reasoning capabilities, etc.)
  - Added `buildModelList()` helper that applies legacy model ID aliases on top of any model list (fetched or static), gracefully skipping aliases when the canonical model is no longer available.

- **index.ts**:
  - Extension factory now fetches models at startup via `fetchNeuralwattModels()`
  - Falls back to the static hardcoded list if the API is unreachable
  - Config update handler preserves fetched models across settings changes (e.g. toggling legacy IDs)

## Motivation

NeuralWatt recently added new models (e.g. `moonshotai/Kimi-K2.7-Code`) that were not available in the hardcoded list. Dynamic fetching ensures pi users always see the latest models without waiting for an extension update.

No breaking changes — if the API is down, behavior is identical to before.