### PR TITLE
feat(provider): rewrite 429 rate-limit errors with layer-specific details

### DIFF
--- a/.changeset/glm-models-sync.md
+++ b/.changeset/glm-models-sync.md
@@ -1,0 +1,5 @@
+---
+"@aliou/pi-neuralwatt": patch
+---
+
+Sync model list with live Neuralwatt API. Add glm-5.2-fast and promote zai-org/GLM-5.1-FP8 from legacy alias to a standalone canonical entry (now serving a GLM-5.2 test build). Update glm-5.1 and glm-5.1-fast context windows to 1048560 (GLM-5.2-backed, 1048K).

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
   ],
   "dependencies": {
     "@aliou/pi-utils-settings": "^0.17.0",
-    "@aliou/pi-utils-ui": "^0.4.0"
+    "@aliou/pi-utils-ui": "^0.4.0",
+    "@earendil-works/pi-ai": "$@earendil-works/pi-coding-agent"
   },
   "peerDependencies": {
     "@earendil-works/pi-coding-agent": "*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,9 @@ importers:
       '@aliou/pi-utils-ui':
         specifier: ^0.4.0
         version: 0.4.1(@earendil-works/pi-coding-agent@0.77.0(ws@8.19.0)(zod@3.25.76))(@earendil-works/pi-tui@0.77.0)
+      '@earendil-works/pi-ai':
+        specifier: 0.77.0
+        version: 0.77.0(ws@8.19.0)(zod@3.25.76)
     devDependencies:
       '@aliou/biome-plugins':
         specifier: ^0.8.1
@@ -168,10 +171,6 @@ packages:
 
   '@aws-sdk/token-providers@3.1056.0':
     resolution: {integrity: sha512-81duvlltQlsfn5K+o8zILcystBRdbT1G2JJYVCML5NZHBz4CL/zf+sAemCtBh/uh6RQUMyInGeZLQ7/8igZhbA==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/types@3.973.8':
-    resolution: {integrity: sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/types@3.973.9':
@@ -776,10 +775,6 @@ packages:
 
   '@smithy/signature-v4@5.4.5':
     resolution: {integrity: sha512-QBJKWGqIknH0dc9LWpfH1mkdokAx6iXYN3UcQ3eY6uIEyScuoQAhfl94ge7ozUy9WgFUdE8xsvwBjaYBbWmPNA==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/types@4.14.1':
-    resolution: {integrity: sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/types@4.14.2':
@@ -1714,7 +1709,7 @@ snapshots:
   '@aws-crypto/crc32@5.2.0':
     dependencies:
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/types': 3.973.9
       tslib: 2.8.1
 
   '@aws-crypto/sha256-browser@5.2.0':
@@ -1722,7 +1717,7 @@ snapshots:
       '@aws-crypto/sha256-js': 5.2.0
       '@aws-crypto/supports-web-crypto': 5.2.0
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/types': 3.973.9
       '@aws-sdk/util-locate-window': 3.965.4
       '@smithy/util-utf8': 2.3.0
       tslib: 2.8.1
@@ -1730,7 +1725,7 @@ snapshots:
   '@aws-crypto/sha256-js@5.2.0':
     dependencies:
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/types': 3.973.9
       tslib: 2.8.1
 
   '@aws-crypto/supports-web-crypto@5.2.0':
@@ -1739,7 +1734,7 @@ snapshots:
 
   '@aws-crypto/util@5.2.0':
     dependencies:
-      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/types': 3.973.9
       '@smithy/util-utf8': 2.3.0
       tslib: 2.8.1
 
@@ -1753,11 +1748,11 @@ snapshots:
       '@aws-sdk/middleware-eventstream': 3.972.14
       '@aws-sdk/middleware-websocket': 3.972.23
       '@aws-sdk/token-providers': 3.1048.0
-      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/types': 3.973.9
       '@smithy/core': 3.24.5
       '@smithy/fetch-http-handler': 5.4.5
-      '@smithy/node-http-handler': 4.7.3
-      '@smithy/types': 4.14.1
+      '@smithy/node-http-handler': 4.7.5
+      '@smithy/types': 4.14.2
       tslib: 2.8.1
 
   '@aws-sdk/core@3.974.15':
@@ -1903,9 +1898,9 @@ snapshots:
     dependencies:
       '@aws-sdk/core': 3.974.15
       '@aws-sdk/nested-clients': 3.997.13
-      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/types': 3.973.9
       '@smithy/core': 3.24.5
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.14.2
       tslib: 2.8.1
 
   '@aws-sdk/token-providers@3.1056.0':
@@ -1915,11 +1910,6 @@ snapshots:
       '@aws-sdk/types': 3.973.9
       '@smithy/core': 3.24.5
       '@smithy/types': 4.14.2
-      tslib: 2.8.1
-
-  '@aws-sdk/types@3.973.8':
-    dependencies:
-      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@aws-sdk/types@3.973.9':
@@ -2519,10 +2509,6 @@ snapshots:
     dependencies:
       '@smithy/core': 3.24.5
       '@smithy/types': 4.14.2
-      tslib: 2.8.1
-
-  '@smithy/types@4.14.1':
-    dependencies:
       tslib: 2.8.1
 
   '@smithy/types@4.14.2':

--- a/src/extensions/provider/index.ts
+++ b/src/extensions/provider/index.ts
@@ -1,3 +1,4 @@
+import { getApiProvider } from "@earendil-works/pi-ai";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import {
   configLoader,
@@ -24,13 +25,18 @@ import {
   normalizeNeuralwattRateLimitError,
   parseRateLimitHeaders,
 } from "./rate-limit-error";
+import { updateQuotasFromSseComment } from "./sse-quotas";
+import { wrapNeuralwattStreamSimple } from "./stream-simple";
 
 const HEADER_EMIT_THROTTLE_MS = 5_000;
 
-function registerNeuralwattProvider(pi: ExtensionAPI): void {
+function registerNeuralwattProvider(
+  pi: ExtensionAPI,
+  onSseQuota: (line: string) => void,
+): void {
   const { includeLegacyModelIds } = configLoader.getConfig();
 
-  pi.registerProvider("neuralwatt", {
+  const config: Parameters<ExtensionAPI["registerProvider"]>[1] = {
     baseUrl: "https://api.neuralwatt.com/v1",
     apiKey: "$NEURALWATT_API_KEY",
     api: "openai-completions",
@@ -42,13 +48,36 @@ function registerNeuralwattProvider(pi: ExtensionAPI): void {
     models: getNeuralwattModels({
       includeLegacyModelIds,
     }),
-  });
+  };
+
+  const provider = getApiProvider("openai-completions");
+  const baseStreamSimple = provider?.streamSimple;
+  if (baseStreamSimple) {
+    config.streamSimple = wrapNeuralwattStreamSimple(
+      baseStreamSimple as never,
+      onSseQuota,
+    ) as never;
+  }
+
+  pi.registerProvider("neuralwatt", config);
 }
 
 export default async function (pi: ExtensionAPI) {
   await configLoader.load();
 
-  registerNeuralwattProvider(pi);
+  let latestQuotas: NeuralwattQuotas | undefined;
+
+  const handleSseQuota = (line: string) => {
+    const quotas = updateQuotasFromSseComment(latestQuotas, line);
+    if (!quotas || quotas === latestQuotas) return;
+    latestQuotas = quotas;
+    pi.events.emit(NEURALWATT_QUOTAS_UPDATED_EVENT, {
+      quotas,
+      source: "sse",
+    });
+  };
+
+  registerNeuralwattProvider(pi, handleSseQuota);
 
   const loadedFeatures = new Set<NeuralwattFeatureId>();
 
@@ -58,7 +87,7 @@ export default async function (pi: ExtensionAPI) {
   });
 
   pi.events.on(NEURALWATT_CONFIG_UPDATED_EVENT, () => {
-    registerNeuralwattProvider(pi);
+    registerNeuralwattProvider(pi, handleSseQuota);
   });
 
   let lastHeaderEmitAt = 0;
@@ -72,6 +101,7 @@ export default async function (pi: ExtensionAPI) {
     if (source === "header" && now - lastHeaderEmitAt < HEADER_EMIT_THROTTLE_MS)
       return;
     if (source === "header") lastHeaderEmitAt = now;
+    latestQuotas = quotas;
     pi.events.emit(NEURALWATT_QUOTAS_UPDATED_EVENT, { quotas, source });
   }
 
@@ -96,7 +126,22 @@ export default async function (pi: ExtensionAPI) {
       pendingRateLimitInfo = undefined;
       return { message };
     }
-    pendingRateLimitInfo = undefined;
+
+    if (
+      event.message.role === "assistant" &&
+      event.message.stopReason === "error" &&
+      (event.message.provider === "neuralwatt" ||
+        ctx.model?.provider === "neuralwatt") &&
+      event.message.errorMessage?.includes("429")
+    ) {
+      return {
+        message: normalizeNeuralwattRateLimitError(event.message, {
+          layer: "unknown",
+          detail:
+            "Neuralwatt rate limit reached, but Pi did not receive layer-specific rate-limit headers. Retry shortly.",
+        }),
+      };
+    }
 
     // Rewrite context overflow errors for Pi's native compaction
     const overflowMessage = normalizeNeuralwattContextOverflowError(
@@ -127,11 +172,7 @@ export default async function (pi: ExtensionAPI) {
     quotaRequestInFlight = true;
     try {
       const quotas = await fetchRequestedQuotas(data);
-      if (quotas)
-        pi.events.emit(NEURALWATT_QUOTAS_UPDATED_EVENT, {
-          quotas,
-          source: "api",
-        });
+      if (quotas) emitQuotas(quotas, "api");
     } finally {
       quotaRequestInFlight = false;
     }

--- a/src/extensions/provider/index.ts
+++ b/src/extensions/provider/index.ts
@@ -19,6 +19,11 @@ import { fetchQuotas } from "../../utils/quotas";
 import { normalizeNeuralwattContextOverflowError } from "./context-overflow";
 import { getNeuralwattModels } from "./models";
 import { buildQuotasFromHeaders, fetchRequestedQuotas } from "./quota-store";
+import {
+  type NeuralwattRateLimitInfo,
+  normalizeNeuralwattRateLimitError,
+  parseRateLimitHeaders,
+} from "./rate-limit-error";
 
 const HEADER_EMIT_THROTTLE_MS = 5_000;
 
@@ -70,17 +75,48 @@ export default async function (pi: ExtensionAPI) {
     pi.events.emit(NEURALWATT_QUOTAS_UPDATED_EVENT, { quotas, source });
   }
 
+  // Stored rate-limit info from the most recent 429 response.
+  // Used in message_end to rewrite the generic error text with
+  // actionable details from Neuralwatt's response headers.
+  let pendingRateLimitInfo: NeuralwattRateLimitInfo | undefined;
+
   pi.on("message_end", (event, ctx) => {
-    const message = normalizeNeuralwattContextOverflowError(
+    // Rewrite rate-limit errors with layer-specific details
+    if (
+      pendingRateLimitInfo &&
+      event.message.role === "assistant" &&
+      event.message.stopReason === "error" &&
+      (event.message.provider === "neuralwatt" ||
+        ctx.model?.provider === "neuralwatt")
+    ) {
+      const message = normalizeNeuralwattRateLimitError(
+        event.message,
+        pendingRateLimitInfo,
+      );
+      pendingRateLimitInfo = undefined;
+      return { message };
+    }
+    pendingRateLimitInfo = undefined;
+
+    // Rewrite context overflow errors for Pi's native compaction
+    const overflowMessage = normalizeNeuralwattContextOverflowError(
       event.message,
       ctx.model?.provider,
     );
-    if (!message) return;
-    return { message };
+    if (!overflowMessage) return;
+    return { message: overflowMessage };
   });
 
   pi.on("after_provider_response", (event, ctx) => {
     if (ctx.model?.provider !== "neuralwatt") return;
+
+    // Capture rate-limit headers from 429 responses for message_end rewriting
+    if (event.status === 429) {
+      pendingRateLimitInfo = parseRateLimitHeaders(event.headers);
+    } else {
+      pendingRateLimitInfo = undefined;
+    }
+
     const quotas = buildQuotasFromHeaders(event.headers);
     if (!quotas) return;
     emitQuotas(quotas, "header");
@@ -107,6 +143,7 @@ export default async function (pi: ExtensionAPI) {
   });
 
   pi.on("session_start", async (_event, ctx) => {
+    pendingRateLimitInfo = undefined;
     for (const message of configLoader.drainMessages()) {
       ctx.ui.notify(message, "warning");
     }

--- a/src/extensions/provider/models.ts
+++ b/src/extensions/provider/models.ts
@@ -24,7 +24,36 @@ export const NEURALWATT_MODELS: ProviderModelConfig[] = [
       maxTokensField: "max_tokens",
     },
   },
+  // GLM-5.1 (200K vLLM deployment) - ZhipuAI
+  // Legacy id previously aliased to glm-5.1; now serving a GLM-5.2 test build.
+  {
+    id: "zai-org/GLM-5.1-FP8",
+    name: "GLM-5.2 (test)",
+    reasoning: true,
+    input: ["text"],
+    cost: {
+      input: 1.1,
+      output: 3.6,
+      cacheRead: 0,
+      cacheWrite: 0,
+    },
+    contextWindow: 202736,
+    maxTokens: 65536,
+    thinkingLevelMap: {
+      minimal: null,
+      low: null,
+      medium: "medium",
+      high: null,
+      xhigh: null,
+    },
+    compat: {
+      supportsDeveloperRole: false,
+      maxTokensField: "max_tokens",
+      requiresReasoningContentOnAssistantMessages: true,
+    },
+  },
   // GLM-5.1 - ZhipuAI
+  // Backed by the 1048K GLM-5.2 deployment (GLM-5.1 redirect in effect). Deprecated.
   {
     id: "glm-5.1",
     name: "GLM-5.1",
@@ -36,7 +65,7 @@ export const NEURALWATT_MODELS: ProviderModelConfig[] = [
       cacheRead: 0,
       cacheWrite: 0,
     },
-    contextWindow: 202736,
+    contextWindow: 1048560,
     maxTokens: 65536,
     thinkingLevelMap: {
       minimal: null,
@@ -63,7 +92,7 @@ export const NEURALWATT_MODELS: ProviderModelConfig[] = [
       cacheRead: 0,
       cacheWrite: 0,
     },
-    contextWindow: 202736,
+    contextWindow: 1048560,
     maxTokens: 65536,
     compat: {
       supportsDeveloperRole: false,
@@ -98,6 +127,25 @@ export const NEURALWATT_MODELS: ProviderModelConfig[] = [
       supportsDeveloperRole: false,
       maxTokensField: "max_tokens",
       requiresReasoningContentOnAssistantMessages: true,
+    },
+  },
+  // GLM-5.2 Fast - ZhipuAI
+  {
+    id: "glm-5.2-fast",
+    name: "GLM-5.2 Fast",
+    reasoning: false,
+    input: ["text"],
+    cost: {
+      input: 1.45,
+      output: 4.5,
+      cacheRead: 0,
+      cacheWrite: 0,
+    },
+    contextWindow: 1048560,
+    maxTokens: 65536,
+    compat: {
+      supportsDeveloperRole: false,
+      maxTokensField: "max_tokens",
     },
   },
   // Kimi K2.5 - MoonshotAI
@@ -315,7 +363,6 @@ export const NEURALWATT_MODELS: ProviderModelConfig[] = [
 ];
 
 const LEGACY_MODEL_ALIAS_MAP = {
-  "zai-org/GLM-5.1-FP8": "glm-5.1",
   "moonshotai/Kimi-K2.6": "kimi-k2.6",
   "Qwen/Qwen3.5-397B-A17B-FP8": "qwen3.5-397b",
   "Qwen/Qwen3.6-35B-A3B": "qwen3.6-35b",

--- a/src/extensions/provider/rate-limit-error.test.ts
+++ b/src/extensions/provider/rate-limit-error.test.ts
@@ -148,6 +148,7 @@ describe("normalizeNeuralwattRateLimitError", () => {
 
     const result = normalizeNeuralwattRateLimitError(baseMessage, info);
     expect(result.errorMessage).not.toBe("Too Many Requests");
+    expect(result.errorMessage).toMatch(/^429 rate limit:/);
     expect(result.errorMessage).toContain("Concurrent request limit reached");
     expect(result.errorMessage).toContain(
       "Retry immediately after an in-flight request completes",

--- a/src/extensions/provider/rate-limit-error.test.ts
+++ b/src/extensions/provider/rate-limit-error.test.ts
@@ -1,0 +1,218 @@
+import { describe, expect, it } from "vitest";
+import type { NeuralwattRateLimitInfo } from "./rate-limit-error";
+import {
+  normalizeNeuralwattRateLimitError,
+  parseRateLimitHeaders,
+} from "./rate-limit-error";
+
+// ---------------------------------------------------------------------------
+// parseRateLimitHeaders
+// ---------------------------------------------------------------------------
+
+describe("parseRateLimitHeaders", () => {
+  it("returns undefined when no rate-limit headers are present", () => {
+    expect(parseRateLimitHeaders({})).toBeUndefined();
+    expect(
+      parseRateLimitHeaders({ "Content-Type": "text/plain" }),
+    ).toBeUndefined();
+  });
+
+  it("parses concurrent-request limit headers", () => {
+    const result = parseRateLimitHeaders({
+      "Retry-After": "0",
+      "X-Concurrent-Limit-Dimension": "user",
+      "X-Concurrent-Limit-Active": "6",
+      "X-Concurrent-Limit-Max": "5",
+    });
+
+    expect(result).toEqual({
+      layer: "concurrent",
+      retryAfter: 0,
+      detail:
+        "Concurrent request limit reached (6/5 active, user-scoped). Wait for an in-flight request to complete before retrying.",
+    });
+  });
+
+  it("parses concurrent limit with model-scoped dimension", () => {
+    const result = parseRateLimitHeaders({
+      "X-Concurrent-Limit-Dimension": "model",
+      "X-Concurrent-Limit-Active": "3",
+      "X-Concurrent-Limit-Max": "2",
+    });
+
+    expect(result?.layer).toBe("concurrent");
+    expect(result?.detail).toContain("model-scoped");
+  });
+
+  it("parses input TPM limit headers", () => {
+    const result = parseRateLimitHeaders({
+      "Retry-After": "45",
+      "X-TPM-Limit-Dimension": "user",
+      "X-TPM-Limit-Tokens": "210000",
+      "X-TPM-Limit-Max": "200000",
+    });
+
+    expect(result).toEqual({
+      layer: "tpm",
+      retryAfter: 45,
+      detail:
+        "Input token rate exceeded (210000/200000 tokens/min, user-scoped). Wait before sending more requests.",
+    });
+  });
+
+  it("parses admission control headers", () => {
+    const result = parseRateLimitHeaders({
+      "Retry-After": "3",
+      "X-Admission-Dimension": "upstream",
+      "X-Admission-InFlight": "210000",
+      "X-Admission-Threshold": "200000",
+    });
+
+    expect(result).toEqual({
+      layer: "admission",
+      retryAfter: 3,
+      detail:
+        "Backend at capacity (210000/200000 in-flight tokens, upstream-scoped). The server is busy — retry shortly.",
+    });
+  });
+
+  it("parses legacy RPM limit headers", () => {
+    const result = parseRateLimitHeaders({
+      "Retry-After": "30",
+      "X-RateLimit-Limit": "500",
+      "X-RateLimit-Remaining": "0",
+      "X-RateLimit-Reset": "1700000000",
+    });
+
+    expect(result).toEqual({
+      layer: "rpm",
+      retryAfter: 30,
+      detail:
+        "Requests per minute exceeded (0/500 remaining). Wait before sending more requests.",
+    });
+  });
+
+  it("handles generic 429 with Retry-After but no layer headers", () => {
+    const result = parseRateLimitHeaders({
+      "Retry-After": "10",
+    });
+
+    expect(result).toEqual({
+      layer: "unknown",
+      retryAfter: 10,
+      detail: "Rate limited by the server. Wait before retrying.",
+    });
+  });
+
+  it("is case-insensitive for header names", () => {
+    const result = parseRateLimitHeaders({
+      "retry-after": "5",
+      "x-concurrent-limit-dimension": "user",
+      "x-concurrent-limit-active": "3",
+      "x-concurrent-limit-max": "2",
+    });
+
+    expect(result?.layer).toBe("concurrent");
+    expect(result?.retryAfter).toBe(5);
+  });
+
+  it("handles missing optional detail headers gracefully", () => {
+    const result = parseRateLimitHeaders({
+      "X-Concurrent-Limit-Dimension": "user",
+    });
+
+    expect(result?.layer).toBe("concurrent");
+    expect(result?.detail).toContain("?/? active");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// normalizeNeuralwattRateLimitError
+// ---------------------------------------------------------------------------
+
+describe("normalizeNeuralwattRateLimitError", () => {
+  const baseMessage = {
+    role: "assistant" as const,
+    stopReason: "error" as const,
+    provider: "neuralwatt",
+    errorMessage: "Too Many Requests",
+  };
+
+  it("rewrites the error message with rate-limit details (concurrent)", () => {
+    const info: NeuralwattRateLimitInfo = {
+      layer: "concurrent",
+      retryAfter: 0,
+      detail:
+        "Concurrent request limit reached (6/5 active, user-scoped). Wait for an in-flight request to complete before retrying.",
+    };
+
+    const result = normalizeNeuralwattRateLimitError(baseMessage, info);
+    expect(result.errorMessage).not.toBe("Too Many Requests");
+    expect(result.errorMessage).toContain("Concurrent request limit reached");
+    expect(result.errorMessage).toContain(
+      "Retry immediately after an in-flight request completes",
+    );
+  });
+
+  it("rewrites the error message with rate-limit details (TPM)", () => {
+    const info: NeuralwattRateLimitInfo = {
+      layer: "tpm",
+      retryAfter: 45,
+      detail:
+        "Input token rate exceeded (210000/200000 tokens/min, user-scoped). Wait before sending more requests.",
+    };
+
+    const result = normalizeNeuralwattRateLimitError(baseMessage, info);
+    expect(result.errorMessage).toContain("Input token rate exceeded");
+    expect(result.errorMessage).toContain("Retry-After: 45s.");
+  });
+
+  it("rewrites the error message with rate-limit details (admission)", () => {
+    const info: NeuralwattRateLimitInfo = {
+      layer: "admission",
+      retryAfter: 120,
+      detail:
+        "Backend at capacity (210000/200000 in-flight tokens, upstream-scoped). The server is busy — retry shortly.",
+    };
+
+    const result = normalizeNeuralwattRateLimitError(baseMessage, info);
+    expect(result.errorMessage).toContain("Backend at capacity");
+    expect(result.errorMessage).toContain("Retry-After: ~2 min.");
+  });
+
+  it("rewrites the error message with rate-limit details (RPM)", () => {
+    const info: NeuralwattRateLimitInfo = {
+      layer: "rpm",
+      retryAfter: 30,
+      detail:
+        "Requests per minute exceeded (0/500 remaining). Wait before sending more requests.",
+    };
+
+    const result = normalizeNeuralwattRateLimitError(baseMessage, info);
+    expect(result.errorMessage).toContain("Requests per minute exceeded");
+    expect(result.errorMessage).toContain("Retry-After: 30s.");
+  });
+
+  it("preserves other message properties", () => {
+    const info: NeuralwattRateLimitInfo = {
+      layer: "concurrent",
+      detail: "Concurrent request limit reached.",
+    };
+
+    const result = normalizeNeuralwattRateLimitError(baseMessage, info);
+    expect(result.role).toBe("assistant");
+    expect(result.stopReason).toBe("error");
+    expect(result.provider).toBe("neuralwatt");
+  });
+
+  it("does not add Retry-After for concurrent with no retryAfter field", () => {
+    const info: NeuralwattRateLimitInfo = {
+      layer: "concurrent",
+      detail: "Concurrent request limit reached.",
+    };
+
+    const result = normalizeNeuralwattRateLimitError(baseMessage, info);
+    expect(result.errorMessage).not.toContain("Retry-After");
+    expect(result.errorMessage).not.toContain("Retry immediately");
+  });
+});

--- a/src/extensions/provider/rate-limit-error.ts
+++ b/src/extensions/provider/rate-limit-error.ts
@@ -129,7 +129,7 @@ function formatRateLimitError(info: NeuralwattRateLimitInfo): string {
     parts.push("Retry immediately after an in-flight request completes.");
   }
 
-  return parts.join(" ");
+  return `429 rate limit: ${parts.join(" ")}`;
 }
 
 /**

--- a/src/extensions/provider/rate-limit-error.ts
+++ b/src/extensions/provider/rate-limit-error.ts
@@ -1,0 +1,150 @@
+interface AssistantErrorLike {
+  role: string;
+  stopReason?: string;
+  provider?: string;
+  errorMessage?: string;
+}
+
+/**
+ * Parsed rate-limit info from Neuralwatt 429 response headers.
+ *
+ * Neuralwatt applies three independent rate-limit layers plus a legacy RPM
+ * layer. Each sets unique headers so the client can tell which layer
+ * triggered the rejection.
+ *
+ * @see https://portal.neuralwatt.com/docs/guides/rate-limits
+ */
+export interface NeuralwattRateLimitInfo {
+  /** Which rate-limit layer triggered the 429 */
+  layer: "concurrent" | "tpm" | "admission" | "rpm" | "unknown";
+  /** Seconds the server recommends waiting before retrying */
+  retryAfter?: number;
+  /** Human-readable details (varies per layer) */
+  detail: string;
+}
+
+/** Case-insensitive header lookup */
+function getHeader(
+  headers: Record<string, string>,
+  name: string,
+): string | undefined {
+  const entry = Object.entries(headers).find(
+    ([key]) => key.toLowerCase() === name.toLowerCase(),
+  );
+  return entry?.[1];
+}
+
+/**
+ * Parse Neuralwatt rate-limit headers from a 429 response.
+ *
+ * Returns `undefined` if no rate-limit-specific headers are found (e.g. the
+ * 429 came from a different proxy or middleware that doesn't set these
+ * headers).
+ */
+export function parseRateLimitHeaders(
+  headers: Record<string, string>,
+): NeuralwattRateLimitInfo | undefined {
+  const retryAfterRaw = getHeader(headers, "Retry-After");
+  const retryAfter = retryAfterRaw
+    ? Number.parseInt(retryAfterRaw, 10)
+    : undefined;
+
+  // 1. Concurrent-request limit
+  const concurrentDimension = getHeader(
+    headers,
+    "X-Concurrent-Limit-Dimension",
+  );
+  if (concurrentDimension) {
+    const active = getHeader(headers, "X-Concurrent-Limit-Active") ?? "?";
+    const max = getHeader(headers, "X-Concurrent-Limit-Max") ?? "?";
+    return {
+      layer: "concurrent",
+      retryAfter,
+      detail: `Concurrent request limit reached (${active}/${max} active, ${concurrentDimension}-scoped). Wait for an in-flight request to complete before retrying.`,
+    };
+  }
+
+  // 2. Input TPM limit
+  const tpmDimension = getHeader(headers, "X-TPM-Limit-Dimension");
+  if (tpmDimension) {
+    const tokens = getHeader(headers, "X-TPM-Limit-Tokens") ?? "?";
+    const max = getHeader(headers, "X-TPM-Limit-Max") ?? "?";
+    return {
+      layer: "tpm",
+      retryAfter,
+      detail: `Input token rate exceeded (${tokens}/${max} tokens/min, ${tpmDimension}-scoped). Wait before sending more requests.`,
+    };
+  }
+
+  // 3. Admission control
+  const admissionDimension = getHeader(headers, "X-Admission-Dimension");
+  if (admissionDimension) {
+    const inFlight = getHeader(headers, "X-Admission-InFlight") ?? "?";
+    const threshold = getHeader(headers, "X-Admission-Threshold") ?? "?";
+    return {
+      layer: "admission",
+      retryAfter,
+      detail: `Backend at capacity (${inFlight}/${threshold} in-flight tokens, ${admissionDimension}-scoped). The server is busy — retry shortly.`,
+    };
+  }
+
+  // 4. Legacy RPM limit
+  const rpmLimit = getHeader(headers, "X-RateLimit-Limit");
+  if (rpmLimit) {
+    const remaining = getHeader(headers, "X-RateLimit-Remaining") ?? "?";
+    return {
+      layer: "rpm",
+      retryAfter,
+      detail: `Requests per minute exceeded (${remaining}/${rpmLimit} remaining). Wait before sending more requests.`,
+    };
+  }
+
+  // Generic 429 with Retry-After but no layer-specific headers
+  if (retryAfter !== undefined) {
+    return {
+      layer: "unknown",
+      retryAfter,
+      detail: "Rate limited by the server. Wait before retrying.",
+    };
+  }
+
+  return undefined;
+}
+
+/**
+ * Build a user-facing error message from a NeuralwattRateLimitInfo.
+ */
+function formatRateLimitError(info: NeuralwattRateLimitInfo): string {
+  const parts = [info.detail];
+
+  if (info.retryAfter !== undefined && info.retryAfter > 0) {
+    if (info.retryAfter < 60) {
+      parts.push(`Retry-After: ${info.retryAfter}s.`);
+    } else {
+      const mins = Math.ceil(info.retryAfter / 60);
+      parts.push(`Retry-After: ~${mins} min.`);
+    }
+  } else if (info.retryAfter === 0 && info.layer === "concurrent") {
+    // Retry-After: 0 means: retry as soon as a slot frees
+    parts.push("Retry immediately after an in-flight request completes.");
+  }
+
+  return parts.join(" ");
+}
+
+/**
+ * Normalize Neuralwatt rate-limit errors so the user sees which layer
+ * triggered the 429 and what to do about it.
+ *
+ * Without this, Pi shows a generic "Too Many Requests" because the
+ * Neuralwatt 429 response body is empty — all diagnostics are in the
+ * response headers.
+ */
+export function normalizeNeuralwattRateLimitError<
+  TMessage extends AssistantErrorLike,
+>(message: TMessage, rateLimitInfo: NeuralwattRateLimitInfo): TMessage {
+  return {
+    ...message,
+    errorMessage: formatRateLimitError(rateLimitInfo),
+  };
+}

--- a/src/extensions/provider/sse-quotas.test.ts
+++ b/src/extensions/provider/sse-quotas.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it, vi } from "vitest";
+import type { NeuralwattQuotas } from "../../types/quota-api";
+import {
+  readQuotaCommentsFromTee,
+  updateQuotasFromSseComment,
+} from "./sse-quotas";
+
+function quotaFixture(): NeuralwattQuotas {
+  return {
+    snapshot_at: "2026-06-17T00:00:00.000Z",
+    balance: {
+      credits_remaining_usd: 10,
+      total_credits_usd: 20,
+      credits_used_usd: 10,
+      accounting_method: "token",
+    },
+    usage: {
+      lifetime: { cost_usd: 5, requests: 100, tokens: 1000, energy_kwh: 1 },
+      current_month: {
+        cost_usd: 2,
+        requests: 10,
+        tokens: 500,
+        energy_kwh: 0.5,
+      },
+    },
+    limits: { overage_limit_usd: null, rate_limit_tier: "standard" },
+    subscription: {
+      plan: "standard",
+      status: "active",
+      billing_interval: "month",
+      current_period_start: "",
+      current_period_end: "",
+      auto_renew: false,
+      kwh_included: 5,
+      kwh_used: 1,
+      kwh_remaining: 4,
+      in_overage: false,
+    },
+    key: { name: "test", allowance: null },
+  };
+}
+
+function streamFromChunks(chunks: string[]): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  return new ReadableStream({
+    start(controller) {
+      for (const chunk of chunks) controller.enqueue(encoder.encode(chunk));
+      controller.close();
+    },
+  });
+}
+
+describe("updateQuotasFromSseComment", () => {
+  it("applies energy comments", () => {
+    const quotas = quotaFixture();
+    const result = updateQuotasFromSseComment(
+      quotas,
+      ': energy {"energy_joules":360000}',
+    );
+
+    expect(result).not.toBe(quotas);
+    expect(result?.usage.current_month.energy_kwh).toBeCloseTo(0.6);
+    expect(result?.usage.lifetime.energy_kwh).toBeCloseTo(1.1);
+    expect(result?.subscription?.kwh_used).toBeCloseTo(1.1);
+    expect(result?.subscription?.kwh_remaining).toBeCloseTo(3.9);
+  });
+
+  it("applies cost comments", () => {
+    const quotas = quotaFixture();
+    const result = updateQuotasFromSseComment(
+      quotas,
+      ': cost {"request_cost_usd":0.25}',
+    );
+
+    expect(result).not.toBe(quotas);
+    expect(result?.balance.credits_remaining_usd).toBeCloseTo(9.75);
+    expect(result?.balance.credits_used_usd).toBeCloseTo(10.25);
+    expect(result?.usage.current_month.cost_usd).toBeCloseTo(2.25);
+    expect(result?.usage.lifetime.cost_usd).toBeCloseTo(5.25);
+  });
+
+  it("ignores malformed and unknown comments", () => {
+    const quotas = quotaFixture();
+    expect(updateQuotasFromSseComment(quotas, ": energy nope")).toBe(quotas);
+    expect(updateQuotasFromSseComment(quotas, ": mcr-session {}")).toBe(quotas);
+  });
+});
+
+describe("readQuotaCommentsFromTee", () => {
+  it("reads comments across split chunks", async () => {
+    const onComment = vi.fn();
+    await readQuotaCommentsFromTee(
+      streamFromChunks([
+        ': energy {"energy_',
+        'joules":360000}\n: cost {"request_cost_usd":',
+        "0.25}\n",
+      ]),
+      onComment,
+    );
+
+    expect(onComment).toHaveBeenCalledWith(': energy {"energy_joules":360000}');
+    expect(onComment).toHaveBeenCalledWith(': cost {"request_cost_usd":0.25}');
+  });
+});

--- a/src/extensions/provider/sse-quotas.ts
+++ b/src/extensions/provider/sse-quotas.ts
@@ -1,0 +1,84 @@
+import type { NeuralwattQuotas } from "../../types/quota-api";
+
+const JOULES_PER_KWH = 3_600_000;
+
+export function updateQuotasFromSseComment(
+  quotas: NeuralwattQuotas | undefined,
+  line: string,
+): NeuralwattQuotas | undefined {
+  if (!quotas) return;
+  const trimmed = line.trim();
+  const next = structuredClone(quotas);
+
+  try {
+    if (trimmed.startsWith(": energy ")) {
+      const energy = JSON.parse(trimmed.slice(9)) as { energy_joules?: number };
+      const energyKwh = (energy.energy_joules ?? 0) / JOULES_PER_KWH;
+      if (energyKwh <= 0) return quotas;
+      next.usage.current_month.energy_kwh += energyKwh;
+      next.usage.lifetime.energy_kwh += energyKwh;
+      if (next.subscription) {
+        next.subscription.kwh_used += energyKwh;
+        next.subscription.kwh_remaining = Math.max(
+          0,
+          next.subscription.kwh_remaining - energyKwh,
+        );
+      }
+      next.snapshot_at = new Date().toISOString();
+      return next;
+    }
+
+    if (trimmed.startsWith(": cost ")) {
+      const cost = JSON.parse(trimmed.slice(7)) as {
+        request_cost_usd?: number;
+      };
+      const requestCostUsd = cost.request_cost_usd ?? 0;
+      if (requestCostUsd <= 0) return quotas;
+      next.balance.credits_remaining_usd = Math.max(
+        0,
+        next.balance.credits_remaining_usd - requestCostUsd,
+      );
+      next.balance.credits_used_usd += requestCostUsd;
+      next.usage.current_month.cost_usd += requestCostUsd;
+      next.usage.lifetime.cost_usd += requestCostUsd;
+      next.snapshot_at = new Date().toISOString();
+      return next;
+    }
+  } catch {
+    return quotas;
+  }
+
+  return quotas;
+}
+
+export async function readQuotaCommentsFromTee(
+  body: ReadableStream<Uint8Array>,
+  onComment: (line: string) => void,
+): Promise<void> {
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      const lines = buffer.split("\n");
+      buffer = lines.pop() ?? "";
+      for (const line of lines) onComment(line);
+    }
+
+    const final = decoder.decode(new Uint8Array(0), { stream: false });
+    const remaining = (buffer + final).trim();
+    if (remaining) onComment(remaining);
+  } catch {
+    // The SDK side may abort the tee; quota comments are best-effort.
+  } finally {
+    try {
+      reader.releaseLock();
+    } catch {
+      // ignore
+    }
+  }
+}

--- a/src/extensions/provider/stream-simple.test.ts
+++ b/src/extensions/provider/stream-simple.test.ts
@@ -1,0 +1,121 @@
+import { createAssistantMessageEventStream } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  type AnyStreamSimple,
+  wrapNeuralwattStreamSimple,
+} from "./stream-simple";
+
+const originalFetch = globalThis.fetch;
+
+function makeAssistantMessage(errorMessage?: string) {
+  return {
+    role: "assistant",
+    api: "openai-completions",
+    provider: "neuralwatt",
+    model: "glm-5.2",
+    stopReason: errorMessage ? "error" : "stop",
+    errorMessage,
+    usage: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    },
+    content: [],
+  };
+}
+
+async function collect(stream: AsyncIterable<unknown>): Promise<unknown[]> {
+  const events: unknown[] = [];
+  for await (const event of stream) events.push(event);
+  return events;
+}
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+describe("wrapNeuralwattStreamSimple", () => {
+  it("rewrites 429 stream errors with captured headers", async () => {
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(null, {
+          status: 429,
+          headers: {
+            "Retry-After": "0",
+            "X-Concurrent-Limit-Dimension": "model",
+            "X-Concurrent-Limit-Active": "3",
+            "X-Concurrent-Limit-Max": "2",
+          },
+        }),
+    );
+    globalThis.fetch = fetchMock as never;
+
+    const base: AnyStreamSimple = () => {
+      const stream = createAssistantMessageEventStream();
+      queueMicrotask(async () => {
+        await fetch("https://api.neuralwatt.com/v1/chat/completions");
+        stream.push({
+          type: "error",
+          reason: "error",
+          error: makeAssistantMessage("429 status code (no body)"),
+        } as never);
+        stream.end();
+      });
+      return stream;
+    };
+
+    const wrapped = wrapNeuralwattStreamSimple(base, () => {});
+    const events = await collect(wrapped({} as never, {} as never));
+    const errorEvent = events.find(
+      (event) => (event as { type?: string }).type === "error",
+    ) as { error: { errorMessage: string; stopReason: string } };
+
+    expect(errorEvent.error.stopReason).toBe("error");
+    expect(errorEvent.error.errorMessage).toContain("429 rate limit:");
+    expect(errorEvent.error.errorMessage).toContain(
+      "Concurrent request limit reached (3/2 active, model-scoped)",
+    );
+    expect(globalThis.fetch).toBe(fetchMock);
+  });
+
+  it("tees successful SSE responses and emits quota comments", async () => {
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(': energy {"energy_joules":360000}\n', {
+          status: 200,
+          headers: { "content-type": "text/event-stream" },
+        }),
+    );
+    globalThis.fetch = fetchMock as never;
+    const onSseQuota = vi.fn();
+
+    const base: AnyStreamSimple = () => {
+      const stream = createAssistantMessageEventStream();
+      queueMicrotask(async () => {
+        const response = await fetch(
+          "https://api.neuralwatt.com/v1/chat/completions",
+        );
+        await response.text();
+        stream.push({
+          type: "done",
+          reason: "stop",
+          message: makeAssistantMessage(),
+        } as never);
+        stream.end();
+      });
+      return stream;
+    };
+
+    const wrapped = wrapNeuralwattStreamSimple(base, onSseQuota);
+    await collect(wrapped({} as never, {} as never));
+
+    expect(onSseQuota).toHaveBeenCalledWith(
+      ': energy {"energy_joules":360000}',
+    );
+    expect(globalThis.fetch).toBe(fetchMock);
+  });
+});

--- a/src/extensions/provider/stream-simple.ts
+++ b/src/extensions/provider/stream-simple.ts
@@ -1,0 +1,107 @@
+import {
+  type AssistantMessageEventStream,
+  type Context,
+  createAssistantMessageEventStream,
+  type Model,
+  type SimpleStreamOptions,
+} from "@earendil-works/pi-ai";
+import {
+  type NeuralwattRateLimitInfo,
+  normalizeNeuralwattRateLimitError,
+  parseRateLimitHeaders,
+} from "./rate-limit-error";
+import { readQuotaCommentsFromTee } from "./sse-quotas";
+
+export type AnyStreamSimple = (
+  model: Model<string>,
+  context: Context,
+  options?: SimpleStreamOptions,
+) => AssistantMessageEventStream;
+
+function headersToRecord(headers: Headers): Record<string, string> {
+  const record: Record<string, string> = {};
+  headers.forEach((value, key) => {
+    record[key] = value;
+  });
+  return record;
+}
+
+export function wrapNeuralwattStreamSimple(
+  base: AnyStreamSimple,
+  onSseQuota: (line: string) => void,
+): AnyStreamSimple {
+  return (model, context, options = {}) => {
+    let rateLimitInfo: NeuralwattRateLimitInfo | undefined;
+    let teeReader: Promise<void> | undefined;
+    const outer = createAssistantMessageEventStream();
+    const originalFetch = globalThis.fetch;
+    const wrappedFetch: typeof fetch = async (input, init) => {
+      const response = await originalFetch(input, init);
+      const url =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : input.url;
+
+      if (!url.includes("/chat/completions")) return response;
+
+      const headers = headersToRecord(response.headers);
+      if (response.status === 429) {
+        rateLimitInfo = parseRateLimitHeaders(headers);
+        return response;
+      }
+
+      if (response.ok && response.body) {
+        const [sdkBody, quotaBody] = response.body.tee();
+        teeReader = readQuotaCommentsFromTee(quotaBody, onSseQuota);
+        return new Response(sdkBody, {
+          headers: response.headers,
+          status: response.status,
+          statusText: response.statusText,
+        });
+      }
+
+      return response;
+    };
+
+    globalThis.fetch = wrappedFetch;
+
+    const restoreFetch = () => {
+      if (globalThis.fetch === wrappedFetch) globalThis.fetch = originalFetch;
+      teeReader?.catch(() => {});
+    };
+
+    const stream = base(model, context, options);
+    const originalOuterEnd = outer.end.bind(outer);
+    outer.end = (result?: Parameters<typeof originalOuterEnd>[0]) => {
+      restoreFetch();
+      originalOuterEnd(result);
+    };
+
+    (async () => {
+      try {
+        for await (const event of stream as AsyncIterable<
+          Parameters<AssistantMessageEventStream["push"]>[0]
+        >) {
+          if (event.type === "error" && rateLimitInfo) {
+            outer.push({
+              ...event,
+              error: normalizeNeuralwattRateLimitError(
+                event.error,
+                rateLimitInfo,
+              ),
+            });
+          } else {
+            outer.push(event);
+          }
+        }
+      } finally {
+        restoreFetch();
+        outer.end();
+      }
+    })();
+
+    return outer;
+  };
+}

--- a/src/types/quota-events.ts
+++ b/src/types/quota-events.ts
@@ -1,6 +1,6 @@
 import type { NeuralwattQuotas } from "./quota-api";
 
-export type QuotaSource = "header" | "api";
+export type QuotaSource = "header" | "api" | "sse";
 
 export const NEURALWATT_QUOTAS_UPDATED_EVENT =
   "neuralwatt:quotas:updated" as const;


### PR DESCRIPTION
## Problem

Neuralwatt returns 429 responses with an empty body — all diagnostic info lives in the response headers (per [the rate limits docs](https://portal.neuralwatt.com/docs/guides/rate-limits)). Pi's OpenAI provider falls back to `statusText` for the error message, so users see a generic `Too Many Requests` with no indication of which limit layer triggered it or what to do about it.

## Solution

Parse Neuralwatt's four rate-limit layers from `after_provider_response` headers and rewrite the finalized error message in `message_end` with layer-specific, actionable detail. Follows the same pattern as the existing `context-overflow.ts` error rewriter.

### New file: `src/extensions/provider/rate-limit-error.ts`

`parseRateLimitHeaders()` detects which of the four layers triggered the 429:

| Layer | Headers | Example error message |
|---|---|---|
| **Concurrent** | `X-Concurrent-Limit-*` | Concurrent request limit reached (6/5 active, user-scoped). Wait for an in-flight request to complete before retrying. |
| **Input TPM** | `X-TPM-Limit-*` | Input token rate exceeded (210000/200000 tokens/min, user-scoped). Wait before sending more requests. |
| **Admission** | `X-Admission-*` | Backend at capacity (210000/200000 in-flight tokens, upstream-scoped). The server is busy — retry shortly. |
| **Legacy RPM** | `X-RateLimit-*` | Requests per minute exceeded (0/500 remaining). Wait before sending more requests. |

Each message includes `Retry-After` guidance when the server provides it. Concurrent limits with `Retry-After: 0` advise retrying immediately after an in-flight request completes (per the docs).

### Modified: `src/extensions/provider/index.ts`

- **`after_provider_response`**: captures 429 headers into `pendingRateLimitInfo`; clears on non-429 responses to avoid stale data
- **`message_end`**: if `pendingRateLimitInfo` exists and the message is a neuralwatt error, rewrites it with the layer-specific details; clears afterwards
- **`session_start`**: clears stale `pendingRateLimitInfo`

### New tests: `src/extensions/provider/rate-limit-error.test.ts`

15 tests covering all four layers, edge cases (missing headers, case-insensitive lookup, generic 429 with only Retry-After), and the `normalizeNeuralwattRateLimitError` output.

## Status

**Draft** — cannot test end-to-end right now because the Neuralwatt API is having issues. Needs verification that:
1. `after_provider_response` fires for 429 responses (not just 2xx)
2. The `pendingRateLimitInfo` handoff between `after_provider_response` and `message_end` works through Pi's retry loop
3. The rewritten message actually surfaces in the UI after retries are exhausted