### PR TITLE
chore: publish glm-5.2-short models

### DIFF
--- a/.changeset/glm-5.2-short-public.md
+++ b/.changeset/glm-5.2-short-public.md
@@ -1,0 +1,5 @@
+---
+"@aliou/pi-neuralwatt": patch
+---
+
+Add glm-5.2-short and glm-5.2-short-fast as public models (they graduated from private/hidden to the public /v1/models list).

--- a/src/extensions/provider/models/hidden.ts
+++ b/src/extensions/provider/models/hidden.ts
@@ -10,19 +10,10 @@ import { NEURALWATT_MODELS } from "./public-models";
 // Per-ID overrides for known hidden models. The authenticated /v1/models endpoint
 // exposes pricing and capabilities, but some Pi-specific behavior (thinking levels,
 // compat flags) has to be supplied by hand.
+// Previously hidden models that have since gone public now live in public-models.ts.
 const HIDDEN_MODEL_OVERRIDES: Partial<
   Record<string, Partial<ProviderModelConfig>>
-> = {
-  "glm-5.2-short": {
-    thinkingLevelMap: {
-      minimal: null,
-      low: null,
-      medium: null,
-      high: "high",
-      xhigh: "max",
-    },
-  },
-};
+> = {};
 
 function buildHiddenModel(apiModel: NeuralwattApiModel): ProviderModelConfig {
   const meta = apiModel.metadata;

--- a/src/extensions/provider/models/public-models.ts
+++ b/src/extensions/provider/models/public-models.ts
@@ -49,6 +49,52 @@ export const NEURALWATT_MODELS: ProviderModelConfig[] = [
       maxTokensField: "max_tokens",
     },
   },
+  // GLM-5.2 Short - ZhipuAI (200K context, bounded reasoning budget)
+  {
+    id: "glm-5.2-short",
+    name: "GLM-5.2 Short",
+    reasoning: true,
+    input: ["text"],
+    cost: {
+      input: 1.45,
+      output: 4.5,
+      cacheRead: 0.3625,
+      cacheWrite: 0,
+    },
+    contextWindow: 199984,
+    maxTokens: 65536,
+    thinkingLevelMap: {
+      minimal: null,
+      low: null,
+      medium: null,
+      high: "high",
+      xhigh: "max",
+    },
+    compat: {
+      supportsDeveloperRole: false,
+      maxTokensField: "max_tokens",
+      requiresReasoningContentOnAssistantMessages: true,
+    },
+  },
+  // GLM-5.2 Short Fast - ZhipuAI (200K context, reasoning disabled)
+  {
+    id: "glm-5.2-short-fast",
+    name: "GLM-5.2 Short Fast",
+    reasoning: false,
+    input: ["text"],
+    cost: {
+      input: 1.45,
+      output: 4.5,
+      cacheRead: 0.3625,
+      cacheWrite: 0,
+    },
+    contextWindow: 199984,
+    maxTokens: 65536,
+    compat: {
+      supportsDeveloperRole: false,
+      maxTokensField: "max_tokens",
+    },
+  },
   // Kimi K2.5 - MoonshotAI
   {
     id: "moonshotai/Kimi-K2.5",


### PR DESCRIPTION
Two previously private/hidden GLM-5.2 short variants now appear in the public (unauthenticated) /v1/models list, so they graduate from hidden-model discovery to hardcoded public models.

- Add `glm-5.2-short` (reasoning, 200K context) — mirrors glm-5.2 thinkingLevelMap and compat
- Add `glm-5.2-short-fast` (non-reasoning, 200K context) — mirrors glm-5.2-fast
- Remove the now-dead `glm-5.2-short` override from HIDDEN_MODEL_OVERRIDES (filtering already excludes public IDs)
- Patch changeset

Verified: models.test.ts reconciles hardcoded defs against live API metadata with 0 discrepancies; typecheck and lint clean.