### PR TITLE
fix: dedupe hidden models and always revalidate cache

### DIFF
--- a/.changeset/fix-hidden-model-graduation.md
+++ b/.changeset/fix-hidden-model-graduation.md
@@ -1,0 +1,6 @@
+---
+"@aliou/pi-neuralwatt": patch
+---
+
+Fix "No models match pattern" warning for models that graduated from hidden to public.
+A stale hidden-models cache could register newly public models twice, making Pi treat the scoped model as ambiguous. Now hidden models are deduped against the public list at registration, and `session_start` always rewrites the cache (even when empty) and re-registers the provider so graduated entries are purged.

--- a/src/extensions/provider/index.ts
+++ b/src/extensions/provider/index.ts
@@ -46,6 +46,11 @@ function registerNeuralwattProvider(
   const { includeLegacyModelIds, includeHiddenModels } =
     configLoader.getConfig();
 
+  const publicModels = getNeuralwattModels({ includeLegacyModelIds });
+  const resolvedHiddenModels = includeHiddenModels
+    ? dedupeHiddenModels(hiddenModels, publicModels)
+    : [];
+
   const config: Parameters<ExtensionAPI["registerProvider"]>[1] = {
     baseUrl: "https://api.neuralwatt.com/v1",
     apiKey: "$NEURALWATT_API_KEY",
@@ -55,10 +60,7 @@ function registerNeuralwattProvider(
       Referer: "https://pi.dev",
       "X-Title": "npm:@aliou/pi-neuralwatt",
     },
-    models: [
-      ...getNeuralwattModels({ includeLegacyModelIds }),
-      ...(includeHiddenModels ? hiddenModels : []),
-    ],
+    models: [...publicModels, ...resolvedHiddenModels],
   };
 
   const provider = getApiProvider("openai-completions");
@@ -71,6 +73,23 @@ function registerNeuralwattProvider(
   }
 
   pi.registerProvider("neuralwatt", config);
+}
+
+/**
+ * Drop any hidden model whose ID collides with a public or legacy model.
+ *
+ * Models can graduate from hidden (authenticated /v1/models only) to public
+ * (unauthenticated list). When that happens, a stale on-disk cache may still
+ * list the now-public ID, which would register it twice and make Pi treat the
+ * scoped model as ambiguous ("No models match pattern"). Dedupe against the
+ * public list so a stale cache can never shadow a public model.
+ */
+function dedupeHiddenModels(
+  hiddenModels: ProviderModelConfig[],
+  publicModels: ProviderModelConfig[],
+): ProviderModelConfig[] {
+  const publicIds = new Set(publicModels.map((m) => m.id));
+  return hiddenModels.filter((m) => !publicIds.has(m.id));
 }
 
 export default async function (pi: ExtensionAPI) {
@@ -254,14 +273,14 @@ export default async function (pi: ExtensionAPI) {
         ctx.modelRegistry.authStorage,
         hiddenModelsAbort.signal,
       );
-      // Persist for the next startup so scoped models resolve without warnings
-      // on Pi's subsequent launches.
-      if (fetched.length > 0) {
-        hiddenModels = fetched;
-        await writeHiddenModelsCache(hiddenModels);
-        if (!hiddenModelsAbort.signal.aborted) {
-          registerNeuralwattProvider(pi, handleSseQuota, hiddenModels);
-        }
+      // Persist for the next startup so scoped models resolve without
+      // warnings on Pi's subsequent launches. Always write the cache (even
+      // when empty) and re-register, so graduated or removed hidden models
+      // are purged from both the cache and the provider's model list.
+      hiddenModels = fetched;
+      await writeHiddenModelsCache(hiddenModels);
+      if (!hiddenModelsAbort.signal.aborted) {
+        registerNeuralwattProvider(pi, handleSseQuota, hiddenModels);
       }
     }
 


### PR DESCRIPTION
## Problem

After models graduate from hidden (authenticated `/v1/models` only) to public (unauthenticated list), a stale on-disk hidden-models cache still lists their IDs. On startup the provider registered them **twice** — once as public, once from the cache — which made Pi treat the scoped model as ambiguous and emit:

```
Warning: No models match pattern "neuralwatt/glm-5.2-short"
```

Pi's `findExactModelReferenceMatch` treats duplicate canonical matches as ambiguous (returns `undefined`), and the partial-match fallback can't match a `provider/model-id` pattern against bare model IDs, so the model is reported as not found even though it is registered (twice).

The stale cache also never self-healed: `session_start` only rewrote the cache and re-registered the provider when `fetched.length > 0`. Once all hidden models had graduated to public, `fetched` was empty, so the guard short-circuited and the stale cache + duplicates persisted into every subsequent launch.

## Fix

Two changes in `src/extensions/provider/index.ts`:

1. **Dedupe at registration** — `dedupeHiddenModels()` filters out any hidden model whose ID collides with a public (or legacy) model before the provider is registered. A stale cache can never shadow a public model again.
2. **Always revalidate** — dropped the `if (fetched.length > 0)` guard in `session_start`. The cache is now always rewritten (even to `[]`) and the provider always re-registers, so graduated or removed hidden models are purged from both the cache and the provider's model list on the next session.

Also cleared the local stale cache file (`~/.pi/agent/cache/-neuralwatt-hidden-models.json`) so the current session is clean.

## Verification

- `pnpm test` — 27 passed
- `pnpm typecheck` — clean
- `pnpm lint` — clean
