### PR TITLE
feat: add Neuralwatt allowances

### DIFF
--- a/.changeset/neuralwatt-allowances.md
+++ b/.changeset/neuralwatt-allowances.md
@@ -1,0 +1,7 @@
+---
+"@aliou/pi-neuralwatt": minor
+---
+
+Add hidden Neuralwatt request/session allowance support.
+
+Allowance config can inject per-session and per-request USD headers, parse session allowance response headers, show an optional editor widget, and warn on low session allowance. The new `/neuralwatt:allowances` command manages these hidden settings with Session and Global tabs.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,12 @@ extensions/
   sub-bar-integration/
     index.ts                            # Extension entry (checks config, sub-bar + status bar)
     snapshot.ts                         # Usage snapshot builder
+  allowances/
+    index.ts                            # Extension entry (request headers, widget, warnings)
+    command.ts                          # /neuralwatt:allowances command
+    headers.ts                          # before_provider_headers allowance injection
+    widget.ts                           # Editor-adjacent allowance widget rendering
+    warnings.ts                         # Session allowance threshold warnings
   _shared/
     auth.ts                             # API key resolution (auth.json -> env var)
 src/
@@ -89,6 +95,21 @@ Two sources of quota data:
 
 2. **API fetch** - `/v1/quota` endpoint returns full balance, usage, limits, and subscription info. Used for the `/neuralwatt:quota` command and initial session fetch.
 
+## Allowance Tracking
+
+The optional hidden allowance extension is configured through `/neuralwatt:allowances` (Session and Global tabs) or direct JSON config edits. It injects request/session allowance headers during `before_provider_headers`:
+
+- `X-Session-ID`
+- `X-Session-Allowance-USD`
+- `X-Request-Allowance-USD`
+
+The provider extension parses only the new allowance response headers in `after_provider_response` and emits `neuralwatt:allowances:updated`:
+
+- `X-Session-Spent-USD`
+- `X-Session-Allowance-Remaining-USD`
+
+Allowance state is header-only. Do not add SSE/local accumulation or backward-compatible allowance header parsing.
+
 ### Subscription vs credits
 
 When a subscription is active, energy is the primary billing method. Credits are on-demand top-up only. The quota warnings system respects this: it only warns about credits when there is no active subscription. When subscribed, only energy warnings are shown.
@@ -108,7 +129,7 @@ When a subscription is active, energy is the primary billing method. Credits are
 - **Legacy model IDs** (`provider.includeLegacyModelIds`) - Include deprecated model aliases
 - **Hidden models** (`provider.includeHiddenModels`) - Include authenticated hidden models
 
-The provider itself cannot be disabled. Settings can also be changed via `pi config`. Existing flat config files are migrated to the nested shape automatically.
+Allowance settings live under `allowances` in config files and are intentionally hidden from `/neuralwatt:settings`; use `/neuralwatt:allowances` instead. The provider itself cannot be disabled. Settings can also be changed via `pi config`. Existing flat config files are migrated to the nested shape automatically.
 
 ## Model loading
 

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ This repository uses [Changesets](https://github.com/changesets/changesets) for 
 
 ## Requirements
 
-- Pi coding agent v0.81.0+
+- Pi coding agent v0.80.8+
 - Neuralwatt API key (configured in `~/.pi/agent/auth.json` or via `NEURALWATT_API_KEY`)
 
 ## Links

--- a/README.md
+++ b/README.md
@@ -70,9 +70,31 @@ When enabled, the extension notifies you when credits or energy are running low.
 
 When a Neuralwatt model is active, the footer status bar shows live quota usage (credits and energy). The status updates after each response and on session start.
 
+### Request and Session Allowances
+
+Configure per-session and per-request USD allowances with:
+
+```text
+/neuralwatt:allowances
+```
+
+The command has **Session** and **Global** tabs. These settings are intentionally hidden from `/neuralwatt:settings`. You can also edit the Neuralwatt config file directly (`~/.pi/agent/extensions/neuralwatt.json` or `.pi/extensions/neuralwatt.json`).
+
+```json
+{
+  "allowances": {
+    "enabled": true,
+    "session": { "enabled": true, "allowanceUsd": 1 },
+    "request": { "enabled": true, "allowanceUsd": 0.05 },
+    "widget": { "enabled": true, "placement": "belowEditor" },
+    "warnings": { "enabled": true, "remainingThresholds": [50, 20, 10] }
+  }
+}
+```
+
 ## Settings
 
-Configure features with `/neuralwatt:settings`:
+Configure visible features with `/neuralwatt:settings`:
 
 - **Quota command** — Show/hide `/neuralwatt:quota`
 - **Quota warnings** — Enable/disable low quota notifications
@@ -80,7 +102,7 @@ Configure features with `/neuralwatt:settings`:
 - **Legacy model IDs** — Include deprecated model aliases
 - **Hidden models** — Include models available only to the configured API key
 
-The provider itself cannot be disabled — it is always loaded.
+The provider itself cannot be disabled — it is always loaded. Allowance settings are managed by `/neuralwatt:allowances` and are not shown in the main settings UI.
 
 Configuration uses nested per-feature sections. Existing flat config files are migrated automatically, with a backup written next to the migrated config.
 
@@ -137,7 +159,7 @@ This repository uses [Changesets](https://github.com/changesets/changesets) for 
 
 ## Requirements
 
-- Pi coding agent v0.80.8+
+- Pi coding agent v0.81.0+
 - Neuralwatt API key (configured in `~/.pi/agent/auth.json` or via `NEURALWATT_API_KEY`)
 
 ## Links

--- a/extensions/allowances/before-provider-headers-contract.test.ts
+++ b/extensions/allowances/before-provider-headers-contract.test.ts
@@ -1,0 +1,27 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const PI_DIST = join(
+  process.cwd(),
+  "node_modules/@earendil-works/pi-coding-agent/dist",
+);
+
+describe("Pi before_provider_headers contract", () => {
+  it("is available in the installed Pi extension API", () => {
+    const extensionTypes = readFileSync(
+      join(PI_DIST, "core/extensions/types.d.ts"),
+      "utf-8",
+    );
+    const runner = readFileSync(
+      join(PI_DIST, "core/extensions/runner.js"),
+      "utf-8",
+    );
+    const sdk = readFileSync(join(PI_DIST, "core/sdk.js"), "utf-8");
+
+    expect(extensionTypes).toContain("BeforeProviderHeadersEvent");
+    expect(extensionTypes).toContain('on(event: "before_provider_headers"');
+    expect(runner).toContain("emitBeforeProviderHeaders");
+    expect(sdk).toContain("before_provider_headers");
+  });
+});

--- a/extensions/allowances/command.test.ts
+++ b/extensions/allowances/command.test.ts
@@ -1,0 +1,121 @@
+import type {
+  SettingsCommandOptions,
+  SettingsSection,
+} from "@aliou/pi-utils-settings";
+import type {
+  ExtensionAPI,
+  ExtensionCommandContext,
+} from "@earendil-works/pi-coding-agent";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { DEFAULT_CONFIG } from "../../src/config/defaults";
+import type {
+  NeuralwattConfig,
+  ResolvedNeuralwattConfig,
+} from "../../src/config/types";
+import { NEURALWATT_CONFIG_UPDATED_EVENT } from "../../src/events";
+
+const settingsMock = vi.hoisted(() => ({
+  options: undefined as unknown,
+}));
+
+const configMock = vi.hoisted(() => ({
+  global: {} as NeuralwattConfig,
+  local: null as NeuralwattConfig | null,
+  resolved: {} as ResolvedNeuralwattConfig,
+  save: vi.fn(),
+}));
+
+vi.mock("@aliou/pi-utils-settings", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@aliou/pi-utils-settings")>()),
+  registerSettingsCommand: (_pi: unknown, options: unknown) => {
+    settingsMock.options = options;
+  },
+}));
+
+vi.mock("../../src/config", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../src/config")>()),
+  configLoader: {
+    getConfig: () => configMock.resolved,
+    getRawConfig: (scope: string) =>
+      scope === "global" ? configMock.global : configMock.local,
+    hasConfig: (scope: string) =>
+      scope === "global" || configMock.local !== null,
+    save: configMock.save,
+  },
+}));
+
+import { registerAllowancesCommand } from "./command";
+
+function options() {
+  return settingsMock.options as SettingsCommandOptions<
+    NeuralwattConfig,
+    ResolvedNeuralwattConfig
+  >;
+}
+
+beforeEach(() => {
+  settingsMock.options = undefined;
+  configMock.global = {};
+  configMock.local = null;
+  configMock.resolved = structuredClone(DEFAULT_CONFIG);
+  configMock.save.mockReset();
+});
+
+describe("registerAllowancesCommand", () => {
+  it("persists only global allowance defaults", async () => {
+    registerAllowancesCommand({
+      events: { emit: vi.fn() },
+    } as unknown as ExtensionAPI);
+
+    expect(options().configStore.getEnabledScopes()).toEqual(["global"]);
+    await expect(options().configStore.save("local", {})).rejects.toThrow(
+      "Allowances only save globally",
+    );
+    await options().configStore.save("global", {
+      allowances: { enabled: true },
+    });
+    expect(configMock.save).toHaveBeenCalledWith("global", {
+      allowances: { enabled: true },
+    });
+  });
+
+  it("shows effective values when project allowances override defaults", () => {
+    configMock.local = { allowances: { enabled: true } };
+    configMock.resolved = {
+      ...structuredClone(DEFAULT_CONFIG),
+      allowances: {
+        ...DEFAULT_CONFIG.allowances,
+        enabled: true,
+        session: { enabled: true, allowanceUsd: 2 },
+        request: { enabled: true, allowanceUsd: 0.1 },
+      },
+    };
+    registerAllowancesCommand({
+      events: { emit: vi.fn() },
+    } as unknown as ExtensionAPI);
+
+    const sections = options().buildSections(
+      {},
+      configMock.resolved,
+      {} as Parameters<ReturnType<typeof options>["buildSections"]>[2],
+    );
+    const override = sections[0] as SettingsSection;
+
+    expect(override.label).toBe("Project override");
+    expect(override.items[0]?.description).toContain("take precedence");
+    expect(override.items[0]?.currentValue).toBe(
+      "enabled · session enabled · cap $2.00 · request enabled · cap $0.10",
+    );
+  });
+
+  it("emits the resolved config after save", async () => {
+    const emit = vi.fn();
+    registerAllowancesCommand({ events: { emit } } as unknown as ExtensionAPI);
+
+    await options().onSave?.({} as ExtensionCommandContext);
+
+    expect(emit).toHaveBeenCalledWith(NEURALWATT_CONFIG_UPDATED_EVENT, {
+      config: configMock.resolved,
+    });
+  });
+});

--- a/extensions/allowances/command.ts
+++ b/extensions/allowances/command.ts
@@ -1,0 +1,523 @@
+import {
+  type ConfigStore,
+  registerSettingsCommand,
+  SettingsDetailEditor,
+  type SettingsSection,
+  type SettingsTheme,
+} from "@aliou/pi-utils-settings";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import {
+  configLoader,
+  DEFAULT_CONFIG,
+  type NeuralwattAllowancesConfig,
+  type NeuralwattConfig,
+  type NeuralwattRawConfig,
+  type ResolvedNeuralwattConfig,
+} from "../../src/config";
+import { NEURALWATT_CONFIG_UPDATED_EVENT } from "../../src/events";
+import { formatUsd } from "../../src/utils/quota-format";
+
+const COMMAND_NAME = "neuralwatt:allowances";
+const NUMBER_PATTERN = /^(?:\d+\.?\d*|\.\d+)$/;
+
+const globalOnlyConfigStore: ConfigStore<
+  NeuralwattConfig,
+  ResolvedNeuralwattConfig
+> = {
+  getConfig: () => configLoader.getConfig(),
+  getRawConfig: (scope) =>
+    scope === "global"
+      ? ((configLoader.getRawConfig("global") ??
+          null) as NeuralwattConfig | null)
+      : null,
+  hasScope: (scope) => scope === "global",
+  hasConfig: (scope) => scope === "global" && configLoader.hasConfig("global"),
+  getEnabledScopes: () => ["global"],
+  save: async (scope, config) => {
+    if (scope !== "global") throw new Error("Allowances only save globally");
+    await configLoader.save("global", config);
+  },
+};
+
+function ensureAllowances(
+  config: NeuralwattConfig,
+): NeuralwattAllowancesConfig {
+  config.allowances ??= {};
+  return config.allowances;
+}
+
+function currentAllowances(
+  config: NeuralwattConfig,
+): NeuralwattAllowancesConfig {
+  return config.allowances ?? {};
+}
+
+function hasAllowanceConfig(
+  config: NeuralwattRawConfig | null,
+): config is NeuralwattConfig {
+  return Boolean(
+    config &&
+      typeof config === "object" &&
+      "allowances" in config &&
+      config.allowances &&
+      typeof config.allowances === "object",
+  );
+}
+
+function boolValue(value: boolean | undefined, fallback: boolean): boolean {
+  return value ?? fallback;
+}
+
+function numberValue(value: number | undefined): string {
+  return value === undefined ? "" : String(value);
+}
+
+function formatOptionalUsd(value: number | undefined): string {
+  return value === undefined ? "unset" : formatUsd(value);
+}
+
+function parseStrictNumber(value: string): number | undefined {
+  const trimmed = value.trim();
+  if (!trimmed || !NUMBER_PATTERN.test(trimmed)) return undefined;
+  const parsed = Number(trimmed);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function parseOptionalNumber(value: string): number | undefined {
+  return parseStrictNumber(value);
+}
+
+function validatePositiveUsd(value: string): string | null {
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  const parsed = parseStrictNumber(trimmed);
+  if (parsed === undefined || parsed <= 0) {
+    return "Enter a positive USD amount, or leave blank to unset.";
+  }
+  return null;
+}
+
+function parseThresholds(value: string): number[] | undefined {
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+  return trimmed
+    .split(/[ ,]+/)
+    .map((part) => parseStrictNumber(part))
+    .filter((value): value is number => value !== undefined);
+}
+
+function validateThresholds(value: string): string | null {
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  const parsed = trimmed.split(/[ ,]+/).map((part) => parseStrictNumber(part));
+  if (parsed.some((threshold) => threshold === undefined)) {
+    return "Enter numbers separated by commas or spaces.";
+  }
+  const thresholds = parsed as number[];
+  if (thresholds.some((threshold) => threshold <= 0 || threshold > 100)) {
+    return "Thresholds must be between 1 and 100.";
+  }
+  return null;
+}
+
+function summaryEnabled(enabled: boolean): string {
+  return enabled ? "enabled" : "disabled";
+}
+
+function featureSummary(config: NeuralwattConfig): string {
+  return summaryEnabled(
+    boolValue(
+      currentAllowances(config).enabled,
+      DEFAULT_CONFIG.allowances.enabled,
+    ),
+  );
+}
+
+function sessionSummary(config: NeuralwattConfig): string {
+  const session = currentAllowances(config).session ?? {};
+  const enabled = boolValue(
+    session.enabled,
+    DEFAULT_CONFIG.allowances.session.enabled,
+  );
+  return `${summaryEnabled(enabled)} · cap ${formatOptionalUsd(session.allowanceUsd)}`;
+}
+
+function requestSummary(config: NeuralwattConfig): string {
+  const request = currentAllowances(config).request ?? {};
+  const enabled = boolValue(
+    request.enabled,
+    DEFAULT_CONFIG.allowances.request.enabled,
+  );
+  return `${summaryEnabled(enabled)} · cap ${formatOptionalUsd(request.allowanceUsd)}`;
+}
+
+function widgetSummary(config: NeuralwattConfig): string {
+  const widget = currentAllowances(config).widget ?? {};
+  const enabled = boolValue(
+    widget.enabled,
+    DEFAULT_CONFIG.allowances.widget.enabled,
+  );
+  return `${summaryEnabled(enabled)} · ${widget.placement ?? DEFAULT_CONFIG.allowances.widget.placement}`;
+}
+
+function warningsSummary(config: NeuralwattConfig): string {
+  const warnings = currentAllowances(config).warnings ?? {};
+  const enabled = boolValue(
+    warnings.enabled,
+    DEFAULT_CONFIG.allowances.warnings.enabled,
+  );
+  const thresholds =
+    warnings.remainingThresholds ??
+    DEFAULT_CONFIG.allowances.warnings.remainingThresholds;
+  return `${summaryEnabled(enabled)} · ${thresholds.join(", ")}%`;
+}
+
+function projectOverrideSection(): SettingsSection[] {
+  if (!hasAllowanceConfig(configLoader.getRawConfig("local"))) return [];
+  return [
+    {
+      label: "Project override",
+      items: [
+        {
+          id: "projectOverride",
+          label: "Project config",
+          description:
+            "This command edits user-wide allowance defaults. This project also has .pi/extensions/neuralwatt.json allowance overrides that may take precedence.",
+          currentValue: "present",
+          values: [],
+        },
+      ],
+    },
+  ];
+}
+
+function setFeatureEnabled(config: NeuralwattConfig, enabled: boolean) {
+  const updated = structuredClone(config);
+  ensureAllowances(updated).enabled = enabled;
+  return updated;
+}
+
+function sessionEditor(
+  baseConfig: NeuralwattConfig,
+  setDraft: (config: NeuralwattConfig) => void,
+  theme: SettingsTheme,
+  onDone: (summary?: string) => void,
+) {
+  const draft = structuredClone(baseConfig);
+  const update = () => setDraft(structuredClone(draft));
+
+  return new SettingsDetailEditor({
+    title: "Session allowance",
+    theme,
+    onDone,
+    getDoneSummary: () => sessionSummary(draft),
+    fields: [
+      {
+        id: "session.enabled",
+        type: "boolean",
+        label: "Enabled",
+        description: "Send X-Session-ID and optional X-Session-Allowance-USD.",
+        getValue: () =>
+          boolValue(
+            currentAllowances(draft).session?.enabled,
+            DEFAULT_CONFIG.allowances.session.enabled,
+          ),
+        setValue: (value) => {
+          const allowances = ensureAllowances(draft);
+          allowances.session ??= {};
+          allowances.session.enabled = value;
+          update();
+        },
+      },
+      {
+        id: "session.allowanceUsd",
+        type: "text",
+        label: "Allowance USD",
+        description: "Blank means no explicit session allowance cap.",
+        getValue: () =>
+          numberValue(currentAllowances(draft).session?.allowanceUsd),
+        setValue: (value) => {
+          const allowances = ensureAllowances(draft);
+          allowances.session ??= {};
+          allowances.session.allowanceUsd = parseOptionalNumber(value);
+          update();
+        },
+        validate: validatePositiveUsd,
+        emptyValueText: "unset",
+      },
+    ],
+  });
+}
+
+function requestEditor(
+  baseConfig: NeuralwattConfig,
+  setDraft: (config: NeuralwattConfig) => void,
+  theme: SettingsTheme,
+  onDone: (summary?: string) => void,
+) {
+  const draft = structuredClone(baseConfig);
+  const update = () => setDraft(structuredClone(draft));
+
+  return new SettingsDetailEditor({
+    title: "Request allowance",
+    theme,
+    onDone,
+    getDoneSummary: () => requestSummary(draft),
+    fields: [
+      {
+        id: "request.enabled",
+        type: "boolean",
+        label: "Enabled",
+        description: "Send X-Request-Allowance-USD when a cap is set.",
+        getValue: () =>
+          boolValue(
+            currentAllowances(draft).request?.enabled,
+            DEFAULT_CONFIG.allowances.request.enabled,
+          ),
+        setValue: (value) => {
+          const allowances = ensureAllowances(draft);
+          allowances.request ??= {};
+          allowances.request.enabled = value;
+          update();
+        },
+      },
+      {
+        id: "request.allowanceUsd",
+        type: "text",
+        label: "Allowance USD",
+        description:
+          "Maximum spend for one Neuralwatt request. Blank unsets it.",
+        getValue: () =>
+          numberValue(currentAllowances(draft).request?.allowanceUsd),
+        setValue: (value) => {
+          const allowances = ensureAllowances(draft);
+          allowances.request ??= {};
+          allowances.request.allowanceUsd = parseOptionalNumber(value);
+          update();
+        },
+        validate: validatePositiveUsd,
+        emptyValueText: "unset",
+      },
+    ],
+  });
+}
+
+function widgetEditor(
+  baseConfig: NeuralwattConfig,
+  setDraft: (config: NeuralwattConfig) => void,
+  theme: SettingsTheme,
+  onDone: (summary?: string) => void,
+) {
+  const draft = structuredClone(baseConfig);
+  const update = () => setDraft(structuredClone(draft));
+
+  return new SettingsDetailEditor({
+    title: "Allowance widget",
+    theme,
+    onDone,
+    getDoneSummary: () => widgetSummary(draft),
+    fields: [
+      {
+        id: "widget.enabled",
+        type: "boolean",
+        label: "Enabled",
+        description: "Show session allowance state near the editor.",
+        getValue: () =>
+          boolValue(
+            currentAllowances(draft).widget?.enabled,
+            DEFAULT_CONFIG.allowances.widget.enabled,
+          ),
+        setValue: (value) => {
+          const allowances = ensureAllowances(draft);
+          allowances.widget ??= {};
+          allowances.widget.enabled = value;
+          update();
+        },
+      },
+      {
+        id: "widget.placement",
+        type: "enum",
+        label: "Placement",
+        options: ["aboveEditor", "belowEditor"],
+        getValue: () =>
+          currentAllowances(draft).widget?.placement ??
+          DEFAULT_CONFIG.allowances.widget.placement,
+        setValue: (value) => {
+          if (value !== "aboveEditor" && value !== "belowEditor") return;
+          const allowances = ensureAllowances(draft);
+          allowances.widget ??= {};
+          allowances.widget.placement = value;
+          update();
+        },
+      },
+    ],
+  });
+}
+
+function warningsEditor(
+  baseConfig: NeuralwattConfig,
+  setDraft: (config: NeuralwattConfig) => void,
+  theme: SettingsTheme,
+  onDone: (summary?: string) => void,
+) {
+  const draft = structuredClone(baseConfig);
+  const update = () => setDraft(structuredClone(draft));
+
+  return new SettingsDetailEditor({
+    title: "Session warnings",
+    theme,
+    onDone,
+    getDoneSummary: () => warningsSummary(draft),
+    fields: [
+      {
+        id: "warnings.enabled",
+        type: "boolean",
+        label: "Enabled",
+        description:
+          "Warn once per crossed threshold in the current Pi session.",
+        getValue: () =>
+          boolValue(
+            currentAllowances(draft).warnings?.enabled,
+            DEFAULT_CONFIG.allowances.warnings.enabled,
+          ),
+        setValue: (value) => {
+          const allowances = ensureAllowances(draft);
+          allowances.warnings ??= {};
+          allowances.warnings.enabled = value;
+          update();
+        },
+      },
+      {
+        id: "warnings.remainingThresholds",
+        type: "text",
+        label: "Thresholds",
+        description: "Remaining percentages, separated by commas or spaces.",
+        getValue: () =>
+          (
+            currentAllowances(draft).warnings?.remainingThresholds ??
+            DEFAULT_CONFIG.allowances.warnings.remainingThresholds
+          ).join(", "),
+        setValue: (value) => {
+          const allowances = ensureAllowances(draft);
+          allowances.warnings ??= {};
+          allowances.warnings.remainingThresholds = parseThresholds(value);
+          update();
+        },
+        validate: validateThresholds,
+      },
+    ],
+  });
+}
+
+export function registerAllowancesCommand(pi: ExtensionAPI): void {
+  registerSettingsCommand<NeuralwattConfig, ResolvedNeuralwattConfig>(pi, {
+    commandName: COMMAND_NAME,
+    commandDescription: "Configure Neuralwatt request and session allowances",
+    title: "Neuralwatt Allowances",
+    configStore: globalOnlyConfigStore,
+    buildSections: (tabConfig, _resolved, ctx): SettingsSection[] => {
+      const config = tabConfig ?? {};
+      return [
+        ...projectOverrideSection(),
+        {
+          label: "Global",
+          items: [
+            {
+              id: "allowances.enabled",
+              label: "Allowance feature",
+              description:
+                "Master switch for allowance headers, widget, and warnings.",
+              currentValue: featureSummary(config),
+              values: ["enabled", "disabled"],
+            },
+            {
+              id: "request",
+              label: "Request allowance",
+              description:
+                "Per-request USD cap applied to each Neuralwatt request.",
+              currentValue: requestSummary(config),
+              values: [],
+              submenu: (_currentValue, done) =>
+                requestEditor(config, ctx.setDraft, ctx.theme, done),
+            },
+          ],
+        },
+      ];
+    },
+    extraTabs: [
+      {
+        id: "session",
+        label: "Session",
+        buildSections: (ctx): SettingsSection[] => {
+          const config =
+            ctx.getDraftForScope("global") ??
+            ctx.getRawForScope("global") ??
+            {};
+          return [
+            ...projectOverrideSection(),
+            {
+              label: "Session",
+              items: [
+                {
+                  id: "session",
+                  label: "Session allowance",
+                  description:
+                    "Per-Pi-session spend cap. Forks naturally use their new Pi session ID.",
+                  currentValue: sessionSummary(config),
+                  values: [],
+                  submenu: (_currentValue, done) =>
+                    sessionEditor(
+                      config,
+                      (updated) => ctx.setDraftForScope("global", updated),
+                      ctx.theme,
+                      done,
+                    ),
+                },
+                {
+                  id: "widget",
+                  label: "Widget",
+                  description:
+                    "Optional editor-adjacent session allowance display.",
+                  currentValue: widgetSummary(config),
+                  values: [],
+                  submenu: (_currentValue, done) =>
+                    widgetEditor(
+                      config,
+                      (updated) => ctx.setDraftForScope("global", updated),
+                      ctx.theme,
+                      done,
+                    ),
+                },
+                {
+                  id: "warnings",
+                  label: "Warnings",
+                  description: "Low session allowance notifications.",
+                  currentValue: warningsSummary(config),
+                  values: [],
+                  submenu: (_currentValue, done) =>
+                    warningsEditor(
+                      config,
+                      (updated) => ctx.setDraftForScope("global", updated),
+                      ctx.theme,
+                      done,
+                    ),
+                },
+              ],
+            },
+          ];
+        },
+      },
+    ],
+    onSettingChange: (id, newValue, config) => {
+      if (id === "allowances.enabled") {
+        return setFeatureEnabled(config, newValue === "enabled");
+      }
+      return null;
+    },
+    onSave: async () => {
+      pi.events.emit(NEURALWATT_CONFIG_UPDATED_EVENT, {
+        config: configLoader.getConfig(),
+      });
+    },
+  });
+}

--- a/extensions/allowances/command.ts
+++ b/extensions/allowances/command.ts
@@ -174,6 +174,7 @@ function warningsSummary(config: NeuralwattConfig): string {
 
 function projectOverrideSection(): SettingsSection[] {
   if (!hasAllowanceConfig(configLoader.getRawConfig("local"))) return [];
+  const effective = configLoader.getConfig();
   return [
     {
       label: "Project override",
@@ -182,8 +183,8 @@ function projectOverrideSection(): SettingsSection[] {
           id: "projectOverride",
           label: "Project config",
           description:
-            "This command edits user-wide allowance defaults. This project also has .pi/extensions/neuralwatt.json allowance overrides that may take precedence.",
-          currentValue: "present",
+            "This command edits user-wide defaults. Project allowances in .pi/extensions/neuralwatt.json take precedence.",
+          currentValue: `${featureSummary(effective)} · session ${sessionSummary(effective)} · request ${requestSummary(effective)}`,
           values: [],
         },
       ],

--- a/extensions/allowances/headers.test.ts
+++ b/extensions/allowances/headers.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { DEFAULT_CONFIG } from "../../src/config";
+import { applyAllowanceHeaders } from "./headers";
+
+describe("applyAllowanceHeaders", () => {
+  it("does nothing when allowances are disabled", () => {
+    const headers: Record<string, string | null | undefined> = {};
+
+    applyAllowanceHeaders(headers, "session-1", DEFAULT_CONFIG.allowances);
+
+    expect(headers).toEqual({});
+  });
+
+  it("injects session and request allowance headers", () => {
+    const headers: Record<string, string | null | undefined> = {};
+
+    applyAllowanceHeaders(headers, "session-1", {
+      ...DEFAULT_CONFIG.allowances,
+      enabled: true,
+      session: { enabled: true, allowanceUsd: 1 },
+      request: { enabled: true, allowanceUsd: 0.05 },
+    });
+
+    expect(headers).toEqual({
+      "X-Session-ID": "session-1",
+      "X-Session-Allowance-USD": "1",
+      "X-Request-Allowance-USD": "0.05",
+    });
+  });
+
+  it("does not inject unset allowance caps", () => {
+    const headers: Record<string, string | null | undefined> = {};
+
+    applyAllowanceHeaders(headers, "session-1", {
+      ...DEFAULT_CONFIG.allowances,
+      enabled: true,
+      session: { enabled: true },
+      request: { enabled: true },
+    });
+
+    expect(headers).toEqual({
+      "X-Session-ID": "session-1",
+    });
+  });
+});

--- a/extensions/allowances/headers.ts
+++ b/extensions/allowances/headers.ts
@@ -1,0 +1,32 @@
+import type { ResolvedNeuralwattConfig } from "../../src/config";
+
+type AllowanceConfig = ResolvedNeuralwattConfig["allowances"];
+
+type MutableHeaders = Record<string, string | null | undefined>;
+
+function usdHeaderValue(value: number): string {
+  return value.toString();
+}
+
+export function applyAllowanceHeaders(
+  headers: MutableHeaders,
+  sessionId: string,
+  config: AllowanceConfig,
+): void {
+  if (!config.enabled) return;
+
+  if (config.session.enabled) {
+    headers["X-Session-ID"] = sessionId;
+    if (config.session.allowanceUsd !== undefined) {
+      headers["X-Session-Allowance-USD"] = usdHeaderValue(
+        config.session.allowanceUsd,
+      );
+    }
+  }
+
+  if (config.request.enabled && config.request.allowanceUsd !== undefined) {
+    headers["X-Request-Allowance-USD"] = usdHeaderValue(
+      config.request.allowanceUsd,
+    );
+  }
+}

--- a/extensions/allowances/index.test.ts
+++ b/extensions/allowances/index.test.ts
@@ -1,0 +1,170 @@
+import type {
+  ExtensionAPI,
+  ExtensionContext,
+} from "@earendil-works/pi-coding-agent";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { DEFAULT_CONFIG } from "../../src/config/defaults";
+import type { ResolvedNeuralwattConfig } from "../../src/config/types";
+import {
+  NEURALWATT_ALLOWANCES_UPDATED_EVENT,
+  NEURALWATT_CONFIG_UPDATED_EVENT,
+  type NeuralwattAllowancesUpdatedPayload,
+} from "../../src/events";
+
+const mocks = vi.hoisted(() => ({
+  config: {} as ResolvedNeuralwattConfig,
+  load: vi.fn(),
+  registerCommand: vi.fn(),
+  checkWarnings: vi.fn(),
+  clearWarnings: vi.fn(),
+}));
+
+vi.mock("../../src/config", () => ({
+  configLoader: {
+    load: mocks.load,
+    getConfig: () => mocks.config,
+  },
+}));
+
+vi.mock("./command", () => ({
+  registerAllowancesCommand: mocks.registerCommand,
+}));
+
+vi.mock("./warnings", () => ({
+  checkAllowanceWarnings: mocks.checkWarnings,
+  clearAllowanceWarningState: mocks.clearWarnings,
+}));
+
+import initializeAllowances from "./index";
+
+type Handler = (event: unknown, ctx: ExtensionContext) => unknown;
+
+function createPi() {
+  const handlers = new Map<string, Handler>();
+  const eventHandlers = new Map<string, (data: unknown) => unknown>();
+  const pi = {
+    on: vi.fn((event: string, handler: Handler) => {
+      handlers.set(event, handler);
+    }),
+    events: {
+      on: vi.fn((event: string, handler: (data: unknown) => unknown) => {
+        eventHandlers.set(event, handler);
+      }),
+    },
+  } as unknown as ExtensionAPI;
+  return { pi, handlers, eventHandlers };
+}
+
+function context(provider = "neuralwatt") {
+  const setWidget = vi.fn();
+  const ctx = {
+    hasUI: true,
+    model: { provider },
+    sessionManager: { getSessionId: () => "session-1" },
+    ui: { setWidget },
+  } as unknown as ExtensionContext;
+  return { ctx, setWidget };
+}
+
+const snapshot: NeuralwattAllowancesUpdatedPayload = {
+  sessionId: "session-1",
+  sessionAllowanceUsd: 1,
+  requestAllowanceUsd: 0.05,
+  sessionSpentUsd: 0.5,
+  sessionAllowanceRemainingUsd: 0.5,
+  updatedAt: "2026-01-01T00:00:00.000Z",
+};
+
+beforeEach(() => {
+  mocks.config = structuredClone(DEFAULT_CONFIG);
+  mocks.load.mockReset();
+  mocks.registerCommand.mockReset();
+  mocks.checkWarnings.mockReset();
+  mocks.clearWarnings.mockReset();
+});
+
+describe("allowances extension", () => {
+  it("injects headers only for Neuralwatt requests", async () => {
+    mocks.config.allowances = {
+      ...DEFAULT_CONFIG.allowances,
+      enabled: true,
+      session: { enabled: true, allowanceUsd: 1 },
+      request: { enabled: true, allowanceUsd: 0.05 },
+    };
+    const { pi, handlers } = createPi();
+    await initializeAllowances(pi);
+    const handler = handlers.get("before_provider_headers");
+    const headers: Record<string, string | null | undefined> = {};
+
+    handler?.({ headers }, context("openai").ctx);
+    expect(headers).toEqual({});
+
+    handler?.({ headers }, context().ctx);
+    expect(headers).toEqual({
+      "X-Session-ID": "session-1",
+      "X-Session-Allowance-USD": "1",
+      "X-Request-Allowance-USD": "0.05",
+    });
+  });
+
+  it("updates and clears the widget across allowance and model events", async () => {
+    mocks.config.allowances = {
+      ...DEFAULT_CONFIG.allowances,
+      enabled: true,
+      widget: { enabled: true, placement: "belowEditor" },
+      warnings: { enabled: true, remainingThresholds: [50, 20, 10] },
+    };
+    const { pi, handlers, eventHandlers } = createPi();
+    const { ctx, setWidget } = context();
+    await initializeAllowances(pi);
+
+    await handlers.get("session_start")?.({}, ctx);
+    eventHandlers.get(NEURALWATT_ALLOWANCES_UPDATED_EVENT)?.(snapshot);
+
+    expect(setWidget).toHaveBeenLastCalledWith(
+      "neuralwatt-allowances",
+      [
+        "Neuralwatt allowance",
+        "Session: $0.50 remaining (50% remaining)",
+        "Spent: $0.50",
+      ],
+      { placement: "belowEditor" },
+    );
+    expect(mocks.checkWarnings).toHaveBeenCalledWith(
+      ctx,
+      snapshot,
+      mocks.config.allowances.warnings,
+    );
+
+    const next = context("openai");
+    handlers.get("model_select")?.({}, next.ctx);
+    expect(next.setWidget).toHaveBeenLastCalledWith(
+      "neuralwatt-allowances",
+      undefined,
+    );
+    expect(mocks.clearWarnings).toHaveBeenCalled();
+  });
+
+  it("applies config updates to active widget state", async () => {
+    mocks.config.allowances = {
+      ...DEFAULT_CONFIG.allowances,
+      enabled: true,
+      widget: { enabled: true, placement: "aboveEditor" },
+    };
+    const { pi, handlers, eventHandlers } = createPi();
+    const { ctx, setWidget } = context();
+    await initializeAllowances(pi);
+    await handlers.get("session_start")?.({}, ctx);
+    eventHandlers.get(NEURALWATT_ALLOWANCES_UPDATED_EVENT)?.(snapshot);
+
+    const disabled = structuredClone(mocks.config);
+    disabled.allowances.enabled = false;
+    eventHandlers.get(NEURALWATT_CONFIG_UPDATED_EVENT)?.({ config: disabled });
+
+    expect(setWidget).toHaveBeenLastCalledWith(
+      "neuralwatt-allowances",
+      undefined,
+    );
+    expect(mocks.clearWarnings).toHaveBeenCalled();
+  });
+});

--- a/extensions/allowances/index.ts
+++ b/extensions/allowances/index.ts
@@ -1,0 +1,127 @@
+import type {
+  ExtensionAPI,
+  ExtensionContext,
+} from "@earendil-works/pi-coding-agent";
+import { configLoader } from "../../src/config";
+import {
+  NEURALWATT_ALLOWANCES_UPDATED_EVENT,
+  NEURALWATT_CONFIG_UPDATED_EVENT,
+  type NeuralwattAllowancesUpdatedPayload,
+  type NeuralwattConfigUpdatedPayload,
+} from "../../src/events";
+import { registerAllowancesCommand } from "./command";
+import { applyAllowanceHeaders } from "./headers";
+import { checkAllowanceWarnings, clearAllowanceWarningState } from "./warnings";
+import { ALLOWANCE_WIDGET_KEY, renderAllowanceWidget } from "./widget";
+
+type BeforeProviderHeadersEvent = {
+  type: "before_provider_headers";
+  headers: Record<string, string | null | undefined>;
+};
+
+type BeforeProviderHeadersHandler = (
+  event: BeforeProviderHeadersEvent,
+  ctx: ExtensionContext,
+) => void | Promise<void>;
+
+export default async function (pi: ExtensionAPI) {
+  await configLoader.load();
+
+  let config = configLoader.getConfig();
+  let currentProvider: string | undefined;
+  let currentContext: ExtensionContext | undefined;
+  let latestSnapshot: NeuralwattAllowancesUpdatedPayload | undefined;
+
+  registerAllowancesCommand(pi);
+
+  function isActive(): boolean {
+    return config.allowances.enabled && currentProvider === "neuralwatt";
+  }
+
+  function clearWidget(ctx = currentContext): void {
+    if (!ctx?.hasUI) return;
+    ctx.ui.setWidget(ALLOWANCE_WIDGET_KEY, undefined);
+  }
+
+  function updateWidget(): void {
+    if (!currentContext?.hasUI) return;
+    if (!isActive() || !config.allowances.widget.enabled || !latestSnapshot) {
+      clearWidget();
+      return;
+    }
+
+    currentContext.ui.setWidget(
+      ALLOWANCE_WIDGET_KEY,
+      renderAllowanceWidget(latestSnapshot, config.allowances),
+      { placement: config.allowances.widget.placement },
+    );
+  }
+
+  // Pi exposes before_provider_headers at runtime before the published 0.80.3
+  // TypeScript declarations include the overload. Keep this local shim until the
+  // dev dependency catches up.
+  const onBeforeProviderHeaders = pi.on as unknown as (
+    event: "before_provider_headers",
+    handler: BeforeProviderHeadersHandler,
+  ) => void;
+
+  onBeforeProviderHeaders("before_provider_headers", (event, ctx) => {
+    if (ctx.model?.provider !== "neuralwatt") return;
+    applyAllowanceHeaders(
+      event.headers,
+      ctx.sessionManager.getSessionId(),
+      config.allowances,
+    );
+  });
+
+  pi.events.on(NEURALWATT_CONFIG_UPDATED_EVENT, (data: unknown) => {
+    config = (data as NeuralwattConfigUpdatedPayload).config;
+    if (!config.allowances.enabled || !config.allowances.warnings.enabled) {
+      clearAllowanceWarningState();
+    }
+    updateWidget();
+  });
+
+  pi.events.on(NEURALWATT_ALLOWANCES_UPDATED_EVENT, (data: unknown) => {
+    if (!data || typeof data !== "object") return;
+    latestSnapshot = data as NeuralwattAllowancesUpdatedPayload;
+    if (!isActive()) return;
+
+    updateWidget();
+    if (currentContext) {
+      checkAllowanceWarnings(
+        currentContext,
+        latestSnapshot,
+        config.allowances.warnings,
+      );
+    }
+  });
+
+  pi.on("session_start", async (_event, ctx) => {
+    currentProvider = ctx.model?.provider;
+    currentContext = ctx;
+    latestSnapshot = undefined;
+    clearAllowanceWarningState();
+    updateWidget();
+  });
+
+  pi.on("model_select", (_event, ctx) => {
+    currentProvider = ctx.model?.provider;
+    currentContext = ctx;
+    if (!isActive()) clearAllowanceWarningState();
+    updateWidget();
+  });
+
+  pi.on("session_before_switch", (_event, ctx) => {
+    currentProvider = ctx.model?.provider;
+    currentContext = ctx;
+  });
+
+  pi.on("session_shutdown", () => {
+    clearWidget();
+    currentProvider = undefined;
+    currentContext = undefined;
+    latestSnapshot = undefined;
+    clearAllowanceWarningState();
+  });
+}

--- a/extensions/allowances/index.ts
+++ b/extensions/allowances/index.ts
@@ -14,16 +14,6 @@ import { applyAllowanceHeaders } from "./headers";
 import { checkAllowanceWarnings, clearAllowanceWarningState } from "./warnings";
 import { ALLOWANCE_WIDGET_KEY, renderAllowanceWidget } from "./widget";
 
-type BeforeProviderHeadersEvent = {
-  type: "before_provider_headers";
-  headers: Record<string, string | null | undefined>;
-};
-
-type BeforeProviderHeadersHandler = (
-  event: BeforeProviderHeadersEvent,
-  ctx: ExtensionContext,
-) => void | Promise<void>;
-
 export default async function (pi: ExtensionAPI) {
   await configLoader.load();
 
@@ -57,15 +47,7 @@ export default async function (pi: ExtensionAPI) {
     );
   }
 
-  // Pi exposes before_provider_headers at runtime before the published 0.80.3
-  // TypeScript declarations include the overload. Keep this local shim until the
-  // dev dependency catches up.
-  const onBeforeProviderHeaders = pi.on as unknown as (
-    event: "before_provider_headers",
-    handler: BeforeProviderHeadersHandler,
-  ) => void;
-
-  onBeforeProviderHeaders("before_provider_headers", (event, ctx) => {
+  pi.on("before_provider_headers", (event, ctx) => {
     if (ctx.model?.provider !== "neuralwatt") return;
     applyAllowanceHeaders(
       event.headers,

--- a/extensions/allowances/warnings.test.ts
+++ b/extensions/allowances/warnings.test.ts
@@ -1,0 +1,87 @@
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { DEFAULT_CONFIG } from "../../src/config";
+import type { NeuralwattAllowancesUpdatedPayload } from "../../src/events";
+import { checkAllowanceWarnings, clearAllowanceWarningState } from "./warnings";
+
+function ctx(notify = vi.fn()): ExtensionContext {
+  return {
+    hasUI: true,
+    ui: { notify },
+  } as unknown as ExtensionContext;
+}
+
+function snapshot(
+  overrides: Partial<NeuralwattAllowancesUpdatedPayload> = {},
+): NeuralwattAllowancesUpdatedPayload {
+  return {
+    sessionId: "session-1",
+    sessionAllowanceUsd: 1,
+    requestAllowanceUsd: null,
+    sessionSpentUsd: 0.8,
+    sessionAllowanceRemainingUsd: 0.2,
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+const warningConfig = {
+  ...DEFAULT_CONFIG.allowances.warnings,
+  enabled: true,
+  remainingThresholds: [50, 20, 10],
+};
+
+beforeEach(() => {
+  clearAllowanceWarningState();
+});
+
+describe("checkAllowanceWarnings", () => {
+  it("warns once for crossed thresholds in a session", () => {
+    const notify = vi.fn();
+    const currentCtx = ctx(notify);
+
+    checkAllowanceWarnings(currentCtx, snapshot(), warningConfig);
+    checkAllowanceWarnings(currentCtx, snapshot(), warningConfig);
+
+    expect(notify).toHaveBeenCalledTimes(1);
+    expect(notify.mock.calls[0][0]).toContain("20% remaining");
+  });
+
+  it("marks higher crossed thresholds when first update is already critical", () => {
+    const notify = vi.fn();
+    const currentCtx = ctx(notify);
+
+    checkAllowanceWarnings(
+      currentCtx,
+      snapshot({ sessionSpentUsd: 0.95, sessionAllowanceRemainingUsd: 0.05 }),
+      warningConfig,
+    );
+    checkAllowanceWarnings(currentCtx, snapshot(), warningConfig);
+
+    expect(notify).toHaveBeenCalledTimes(1);
+    expect(notify.mock.calls[0][1]).toBe("error");
+  });
+
+  it("does not warn without remaining allowance state", () => {
+    const notify = vi.fn();
+
+    checkAllowanceWarnings(
+      ctx(notify),
+      snapshot({ sessionAllowanceRemainingUsd: null }),
+      warningConfig,
+    );
+
+    expect(notify).not.toHaveBeenCalled();
+  });
+
+  it("does not warn when warnings are disabled", () => {
+    const notify = vi.fn();
+
+    checkAllowanceWarnings(ctx(notify), snapshot(), {
+      ...warningConfig,
+      enabled: false,
+    });
+
+    expect(notify).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/allowances/warnings.ts
+++ b/extensions/allowances/warnings.ts
@@ -1,0 +1,62 @@
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+import type { ResolvedNeuralwattConfig } from "../../src/config";
+import type { NeuralwattAllowancesUpdatedPayload } from "../../src/events";
+import { formatUsd } from "../../src/utils/quota-format";
+
+type AllowanceWarningsConfig =
+  ResolvedNeuralwattConfig["allowances"]["warnings"];
+
+const warnedThresholdsBySession = new Map<string, Set<number>>();
+
+export function clearAllowanceWarningState(): void {
+  warnedThresholdsBySession.clear();
+}
+
+function remainingPercent(
+  snapshot: NeuralwattAllowancesUpdatedPayload,
+): number | undefined {
+  if (snapshot.sessionAllowanceRemainingUsd === null) return;
+  const total =
+    snapshot.sessionSpentUsd + snapshot.sessionAllowanceRemainingUsd;
+  if (total <= 0) return;
+  return (snapshot.sessionAllowanceRemainingUsd / total) * 100;
+}
+
+function normalizeThresholds(thresholds: number[]): number[] {
+  return [...new Set(thresholds)]
+    .filter((threshold) => threshold > 0 && threshold <= 100)
+    .sort((a, b) => b - a);
+}
+
+export function checkAllowanceWarnings(
+  ctx: ExtensionContext,
+  snapshot: NeuralwattAllowancesUpdatedPayload,
+  config: AllowanceWarningsConfig,
+): void {
+  if (!ctx.hasUI) return;
+  if (!config.enabled) return;
+
+  const pct = remainingPercent(snapshot);
+  if (pct === undefined) return;
+
+  const thresholds = normalizeThresholds(config.remainingThresholds);
+  if (thresholds.length === 0) return;
+
+  const warned = warnedThresholdsBySession.get(snapshot.sessionId) ?? new Set();
+  const crossed = thresholds.filter(
+    (threshold) => pct <= threshold && !warned.has(threshold),
+  );
+  if (crossed.length === 0) return;
+
+  for (const threshold of crossed) warned.add(threshold);
+  warnedThresholdsBySession.set(snapshot.sessionId, warned);
+
+  const activeThreshold = Math.min(...crossed);
+  const level = activeThreshold <= 10 ? "error" : "warning";
+  ctx.ui.notify(
+    `Neuralwatt session allowance warning:\n  - ${pct.toFixed(0)}% remaining (${formatUsd(
+      snapshot.sessionAllowanceRemainingUsd ?? 0,
+    )} remaining; ${formatUsd(snapshot.sessionSpentUsd)} spent)`,
+    level,
+  );
+}

--- a/extensions/allowances/widget.test.ts
+++ b/extensions/allowances/widget.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { DEFAULT_CONFIG } from "../../src/config";
+import type { NeuralwattAllowancesUpdatedPayload } from "../../src/events";
+import { renderAllowanceWidget } from "./widget";
+
+function snapshot(
+  overrides: Partial<NeuralwattAllowancesUpdatedPayload> = {},
+): NeuralwattAllowancesUpdatedPayload {
+  return {
+    sessionId: "session-1",
+    sessionAllowanceUsd: 1,
+    requestAllowanceUsd: 0.05,
+    sessionSpentUsd: 0.75,
+    sessionAllowanceRemainingUsd: 0.25,
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("renderAllowanceWidget", () => {
+  it("renders remaining session allowance and the configured request cap", () => {
+    expect(
+      renderAllowanceWidget(snapshot(), {
+        ...DEFAULT_CONFIG.allowances,
+        request: { enabled: true, allowanceUsd: 0.05 },
+      }),
+    ).toEqual([
+      "Neuralwatt allowance",
+      "Session: $0.25 remaining (25% remaining)",
+      "Spent: $0.75",
+      "Request cap: $0.05",
+    ]);
+  });
+
+  it("renders spent-only state when no session cap is reported", () => {
+    expect(
+      renderAllowanceWidget(
+        snapshot({ sessionAllowanceRemainingUsd: null }),
+        DEFAULT_CONFIG.allowances,
+      ),
+    ).toEqual(["Neuralwatt allowance", "Session spent: $0.75"]);
+  });
+});

--- a/extensions/allowances/widget.ts
+++ b/extensions/allowances/widget.ts
@@ -1,0 +1,41 @@
+import type { ResolvedNeuralwattConfig } from "../../src/config";
+import type { NeuralwattAllowancesUpdatedPayload } from "../../src/events";
+import { formatUsd } from "../../src/utils/quota-format";
+
+type AllowanceConfig = ResolvedNeuralwattConfig["allowances"];
+
+export const ALLOWANCE_WIDGET_KEY = "neuralwatt-allowances";
+
+function percentRemaining(
+  snapshot: NeuralwattAllowancesUpdatedPayload,
+): number | undefined {
+  if (snapshot.sessionAllowanceRemainingUsd === null) return;
+  const total =
+    snapshot.sessionSpentUsd + snapshot.sessionAllowanceRemainingUsd;
+  if (total <= 0) return;
+  return Math.round((snapshot.sessionAllowanceRemainingUsd / total) * 100);
+}
+
+export function renderAllowanceWidget(
+  snapshot: NeuralwattAllowancesUpdatedPayload,
+  config: AllowanceConfig,
+): string[] {
+  const lines: string[] = ["Neuralwatt allowance"];
+  const pct = percentRemaining(snapshot);
+
+  if (snapshot.sessionAllowanceRemainingUsd === null) {
+    lines.push(`Session spent: ${formatUsd(snapshot.sessionSpentUsd)}`);
+  } else {
+    const suffix = pct === undefined ? "" : ` (${pct}% remaining)`;
+    lines.push(
+      `Session: ${formatUsd(snapshot.sessionAllowanceRemainingUsd)} remaining${suffix}`,
+    );
+    lines.push(`Spent: ${formatUsd(snapshot.sessionSpentUsd)}`);
+  }
+
+  if (config.request.enabled && config.request.allowanceUsd !== undefined) {
+    lines.push(`Request cap: ${formatUsd(config.request.allowanceUsd)}`);
+  }
+
+  return lines;
+}

--- a/extensions/provider/allowance-store.test.ts
+++ b/extensions/provider/allowance-store.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { DEFAULT_CONFIG } from "../../src/config";
+import { buildAllowancesFromHeaders } from "./allowance-store";
+
+describe("buildAllowancesFromHeaders", () => {
+  it("returns undefined when allowance headers are absent", () => {
+    expect(
+      buildAllowancesFromHeaders({}, "session-1", DEFAULT_CONFIG.allowances),
+    ).toBeUndefined();
+  });
+
+  it("builds an allowance snapshot from response headers and config", () => {
+    const snapshot = buildAllowancesFromHeaders(
+      {
+        "X-Session-Spent-USD": "0.25",
+        "X-Session-Allowance-Remaining-USD": "0.75",
+      },
+      "session-1",
+      {
+        ...DEFAULT_CONFIG.allowances,
+        enabled: true,
+        session: { enabled: true, allowanceUsd: 1 },
+        request: { enabled: true, allowanceUsd: 0.05 },
+      },
+    );
+
+    expect(snapshot).toMatchObject({
+      sessionId: "session-1",
+      sessionAllowanceUsd: 1,
+      requestAllowanceUsd: 0.05,
+      sessionSpentUsd: 0.25,
+      sessionAllowanceRemainingUsd: 0.75,
+    });
+    expect(snapshot?.updatedAt).toEqual(expect.any(String));
+  });
+
+  it("omits configured caps when their scopes are disabled", () => {
+    const snapshot = buildAllowancesFromHeaders(
+      { "X-Session-Spent-USD": "0.25" },
+      "session-1",
+      {
+        ...DEFAULT_CONFIG.allowances,
+        enabled: true,
+        session: { enabled: false, allowanceUsd: 1 },
+        request: { enabled: false, allowanceUsd: 0.05 },
+      },
+    );
+
+    expect(snapshot).toMatchObject({
+      sessionAllowanceUsd: null,
+      requestAllowanceUsd: null,
+    });
+  });
+});

--- a/extensions/provider/allowance-store.ts
+++ b/extensions/provider/allowance-store.ts
@@ -1,0 +1,34 @@
+import type { ResolvedNeuralwattConfig } from "../../src/config";
+import {
+  type NeuralwattAllowancesUpdatedPayload,
+  parseAllowanceHeaders,
+} from "../../src/events";
+
+type AllowanceConfig = ResolvedNeuralwattConfig["allowances"];
+
+export function buildAllowancesFromHeaders(
+  headers: Record<string, string>,
+  sessionId: string,
+  config: AllowanceConfig,
+): NeuralwattAllowancesUpdatedPayload | undefined {
+  const headerAllowances = parseAllowanceHeaders(headers);
+  if (!headerAllowances) return;
+
+  return {
+    sessionId,
+    sessionAllowanceUsd:
+      config.enabled &&
+      config.session.enabled &&
+      config.session.allowanceUsd !== undefined
+        ? config.session.allowanceUsd
+        : null,
+    requestAllowanceUsd:
+      config.enabled &&
+      config.request.enabled &&
+      config.request.allowanceUsd !== undefined
+        ? config.request.allowanceUsd
+        : null,
+    ...headerAllowances,
+    updatedAt: new Date().toISOString(),
+  };
+}

--- a/extensions/provider/commands/settings/index.ts
+++ b/extensions/provider/commands/settings/index.ts
@@ -94,6 +94,10 @@ function toNestedConfig(config: NeuralwattRawConfig): NeuralwattConfig {
         : {}),
       enabled: optionalFeatureValue(config.subBarIntegration),
     },
+    allowances:
+      "allowances" in config && typeof config.allowances === "object"
+        ? config.allowances
+        : undefined,
   };
 }
 

--- a/extensions/provider/index.ts
+++ b/extensions/provider/index.ts
@@ -5,6 +5,7 @@ import type {
 } from "@earendil-works/pi-coding-agent";
 import { configLoader } from "../../src/config";
 import {
+  NEURALWATT_ALLOWANCES_UPDATED_EVENT,
   NEURALWATT_CONFIG_UPDATED_EVENT,
   NEURALWATT_EXTENSIONS_REGISTER_EVENT,
   NEURALWATT_EXTENSIONS_REQUEST_EVENT,
@@ -16,6 +17,7 @@ import {
 import { fetchQuotas } from "../../src/lib/neuralwatt-api";
 import type { NeuralwattQuotas } from "../../src/types/quota-api";
 import { getNeuralwattApiKey } from "../_shared/auth";
+import { buildAllowancesFromHeaders } from "./allowance-store";
 import { registerNeuralwattSettings } from "./commands/settings";
 import { normalizeNeuralwattContextOverflowError } from "./context-overflow";
 import { getNeuralwattModels, refreshNeuralwattModels } from "./models";
@@ -202,6 +204,15 @@ export default async function (pi: ExtensionAPI) {
       pendingRateLimitInfo = parseRateLimitHeaders(event.headers);
     } else {
       pendingRateLimitInfo = undefined;
+    }
+
+    const allowance = buildAllowancesFromHeaders(
+      event.headers,
+      ctx.sessionManager.getSessionId(),
+      configLoader.getConfig().allowances,
+    );
+    if (allowance) {
+      pi.events.emit(NEURALWATT_ALLOWANCES_UPDATED_EVENT, allowance);
     }
 
     const quotas = buildQuotasFromHeaders(event.headers);

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "peerDependencies": {
     "@earendil-works/pi-ai": ">=0.80.8",
-    "@earendil-works/pi-coding-agent": ">=0.81.0",
+    "@earendil-works/pi-coding-agent": ">=0.80.8",
     "@earendil-works/pi-tui": "*"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "pi": {
     "extensions": [
       "./extensions/provider/index.ts",
+      "./extensions/allowances/index.ts",
       "./extensions/command-quotas/index.ts",
       "./extensions/quota-warnings/index.ts",
       "./extensions/sub-bar-integration/index.ts"
@@ -39,7 +40,7 @@
   },
   "peerDependencies": {
     "@earendil-works/pi-ai": ">=0.80.8",
-    "@earendil-works/pi-coding-agent": ">=0.80.8",
+    "@earendil-works/pi-coding-agent": ">=0.81.0",
     "@earendil-works/pi-tui": "*"
   },
   "devDependencies": {

--- a/schema.json
+++ b/schema.json
@@ -2,12 +2,87 @@
   "$ref": "#/definitions/NeuralwattConfig",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
+    "NeuralwattAllowanceLimitConfig": {
+      "additionalProperties": false,
+      "properties": {
+        "allowanceUsd": {
+          "description": "Maximum spend in USD for this allowance scope.",
+          "type": "number"
+        },
+        "enabled": {
+          "description": "Send this allowance header on Neuralwatt requests.",
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "NeuralwattAllowanceWarningsConfig": {
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "description": "Show warnings when session allowance is low.",
+          "type": "boolean"
+        },
+        "remainingThresholds": {
+          "description": "Remaining-percent thresholds that trigger one warning per session.",
+          "items": {
+            "type": "number"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "NeuralwattAllowanceWidgetConfig": {
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "description": "Show Neuralwatt allowance state near the editor.",
+          "type": "boolean"
+        },
+        "placement": {
+          "$ref": "#/definitions/NeuralwattWidgetPlacement",
+          "description": "Place the widget above or below the editor."
+        }
+      },
+      "type": "object"
+    },
+    "NeuralwattAllowancesConfig": {
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "description": "Inject Neuralwatt allowance headers and display allowance state.",
+          "type": "boolean"
+        },
+        "request": {
+          "$ref": "#/definitions/NeuralwattAllowanceLimitConfig",
+          "description": "Per-request allowance behavior."
+        },
+        "session": {
+          "$ref": "#/definitions/NeuralwattAllowanceLimitConfig",
+          "description": "Per-session allowance behavior."
+        },
+        "warnings": {
+          "$ref": "#/definitions/NeuralwattAllowanceWarningsConfig",
+          "description": "Session allowance warnings."
+        },
+        "widget": {
+          "$ref": "#/definitions/NeuralwattAllowanceWidgetConfig",
+          "description": "Editor-adjacent allowance widget."
+        }
+      },
+      "type": "object"
+    },
     "NeuralwattConfig": {
       "additionalProperties": false,
       "properties": {
         "$schema": {
           "description": "$schema URL for editor autocomplete.",
           "type": "string"
+        },
+        "allowances": {
+          "$ref": "#/definitions/NeuralwattAllowancesConfig",
+          "description": "Hidden Neuralwatt request/session allowance controls."
         },
         "provider": {
           "$ref": "#/definitions/NeuralwattProviderConfig",
@@ -71,6 +146,13 @@
         }
       },
       "type": "object"
+    },
+    "NeuralwattWidgetPlacement": {
+      "enum": [
+        "aboveEditor",
+        "belowEditor"
+      ],
+      "type": "string"
     }
   }
 }

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -14,4 +14,21 @@ export const DEFAULT_CONFIG: ResolvedNeuralwattConfig = {
   subBarIntegration: {
     enabled: true,
   },
+  allowances: {
+    enabled: false,
+    session: {
+      enabled: true,
+    },
+    request: {
+      enabled: false,
+    },
+    widget: {
+      enabled: false,
+      placement: "belowEditor",
+    },
+    warnings: {
+      enabled: false,
+      remainingThresholds: [50, 20, 10],
+    },
+  },
 };

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -2,8 +2,10 @@ export { DEFAULT_CONFIG } from "./defaults";
 export { configLoader } from "./loader";
 export { migrations } from "./migration";
 export type {
+  NeuralwattAllowancesConfig,
   NeuralwattConfig,
   NeuralwattRawConfig,
+  NeuralwattWidgetPlacement,
   PreviousNeuralwattConfig,
   ResolvedNeuralwattConfig,
 } from "./types";

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -2,7 +2,11 @@ import { buildSchemaUrl, ConfigLoader } from "@aliou/pi-utils-settings";
 import packageJson from "../../package.json";
 import { DEFAULT_CONFIG } from "./defaults";
 import { migrations } from "./migration";
-import type { NeuralwattRawConfig, ResolvedNeuralwattConfig } from "./types";
+import type {
+  NeuralwattRawConfig,
+  NeuralwattWidgetPlacement,
+  ResolvedNeuralwattConfig,
+} from "./types";
 
 type ConfigRecord = Record<string, unknown>;
 
@@ -10,6 +14,20 @@ type MaybeEnabled = { enabled?: boolean };
 type MaybeProvider = {
   includeLegacyModelIds?: boolean;
   includeHiddenModels?: boolean;
+};
+
+type MaybeAllowanceLimit = MaybeEnabled & { allowanceUsd?: number };
+type MaybeAllowanceWidget = MaybeEnabled & {
+  placement?: NeuralwattWidgetPlacement;
+};
+type MaybeAllowanceWarnings = MaybeEnabled & {
+  remainingThresholds?: number[];
+};
+type MaybeAllowances = MaybeEnabled & {
+  session?: MaybeAllowanceLimit;
+  request?: MaybeAllowanceLimit;
+  widget?: MaybeAllowanceWidget;
+  warnings?: MaybeAllowanceWarnings;
 };
 
 function featureEnabled(value: unknown, fallback: boolean): boolean {
@@ -21,14 +39,46 @@ function featureEnabled(value: unknown, fallback: boolean): boolean {
   return fallback;
 }
 
+function objectValue<T extends object>(value: unknown): Partial<T> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Partial<T>)
+    : {};
+}
+
+function optionalPositiveNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value > 0
+    ? value
+    : undefined;
+}
+
+function thresholds(value: unknown, fallback: number[]): number[] {
+  if (!Array.isArray(value)) return fallback;
+  const parsed = value.filter(
+    (threshold): threshold is number =>
+      typeof threshold === "number" && Number.isFinite(threshold),
+  );
+  return parsed.length > 0 ? parsed : fallback;
+}
+
+function widgetPlacement(
+  value: unknown,
+  fallback: NeuralwattWidgetPlacement,
+): NeuralwattWidgetPlacement {
+  return value === "aboveEditor" || value === "belowEditor" ? value : fallback;
+}
+
 function normalizeResolvedConfig(
   resolved: ResolvedNeuralwattConfig,
 ): ResolvedNeuralwattConfig {
   const record = resolved as unknown as ConfigRecord;
-  const provider =
-    record.provider && typeof record.provider === "object"
-      ? (record.provider as MaybeProvider)
-      : {};
+  const provider = objectValue<MaybeProvider>(record.provider);
+  const allowances = objectValue<MaybeAllowances>(record.allowances);
+  const sessionAllowance = objectValue<MaybeAllowanceLimit>(allowances.session);
+  const requestAllowance = objectValue<MaybeAllowanceLimit>(allowances.request);
+  const allowanceWidget = objectValue<MaybeAllowanceWidget>(allowances.widget);
+  const allowanceWarnings = objectValue<MaybeAllowanceWarnings>(
+    allowances.warnings,
+  );
 
   return {
     provider: {
@@ -60,6 +110,46 @@ function normalizeResolvedConfig(
         record.subBarIntegration,
         DEFAULT_CONFIG.subBarIntegration.enabled,
       ),
+    },
+    allowances: {
+      enabled: featureEnabled(
+        record.allowances,
+        DEFAULT_CONFIG.allowances.enabled,
+      ),
+      session: {
+        enabled: featureEnabled(
+          allowances.session,
+          DEFAULT_CONFIG.allowances.session.enabled,
+        ),
+        allowanceUsd: optionalPositiveNumber(sessionAllowance.allowanceUsd),
+      },
+      request: {
+        enabled: featureEnabled(
+          allowances.request,
+          DEFAULT_CONFIG.allowances.request.enabled,
+        ),
+        allowanceUsd: optionalPositiveNumber(requestAllowance.allowanceUsd),
+      },
+      widget: {
+        enabled: featureEnabled(
+          allowances.widget,
+          DEFAULT_CONFIG.allowances.widget.enabled,
+        ),
+        placement: widgetPlacement(
+          allowanceWidget.placement,
+          DEFAULT_CONFIG.allowances.widget.placement,
+        ),
+      },
+      warnings: {
+        enabled: featureEnabled(
+          allowances.warnings,
+          DEFAULT_CONFIG.allowances.warnings.enabled,
+        ),
+        remainingThresholds: thresholds(
+          allowanceWarnings.remainingThresholds,
+          DEFAULT_CONFIG.allowances.warnings.remainingThresholds,
+        ),
+      },
     },
   };
 }

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -41,6 +41,49 @@ export interface NeuralwattSubBarIntegrationConfig {
   enabled?: boolean;
 }
 
+export type NeuralwattWidgetPlacement = "aboveEditor" | "belowEditor";
+
+export interface NeuralwattAllowanceLimitConfig {
+  /** Send this allowance header on Neuralwatt requests. */
+  enabled?: boolean;
+
+  /** Maximum spend in USD for this allowance scope. */
+  allowanceUsd?: number;
+}
+
+export interface NeuralwattAllowanceWidgetConfig {
+  /** Show Neuralwatt allowance state near the editor. */
+  enabled?: boolean;
+
+  /** Place the widget above or below the editor. */
+  placement?: NeuralwattWidgetPlacement;
+}
+
+export interface NeuralwattAllowanceWarningsConfig {
+  /** Show warnings when session allowance is low. */
+  enabled?: boolean;
+
+  /** Remaining-percent thresholds that trigger one warning per session. */
+  remainingThresholds?: number[];
+}
+
+export interface NeuralwattAllowancesConfig {
+  /** Inject Neuralwatt allowance headers and display allowance state. */
+  enabled?: boolean;
+
+  /** Per-session allowance behavior. */
+  session?: NeuralwattAllowanceLimitConfig;
+
+  /** Per-request allowance behavior. */
+  request?: NeuralwattAllowanceLimitConfig;
+
+  /** Editor-adjacent allowance widget. */
+  widget?: NeuralwattAllowanceWidgetConfig;
+
+  /** Session allowance warnings. */
+  warnings?: NeuralwattAllowanceWarningsConfig;
+}
+
 export interface NeuralwattConfig {
   /** $schema URL for editor autocomplete. */
   $schema?: string;
@@ -56,6 +99,9 @@ export interface NeuralwattConfig {
 
   /** Sub-bar/status-bar integration feature. */
   subBarIntegration?: NeuralwattSubBarIntegrationConfig;
+
+  /** Hidden Neuralwatt request/session allowance controls. */
+  allowances?: NeuralwattAllowancesConfig;
 }
 
 export type NeuralwattRawConfig = PreviousNeuralwattConfig | NeuralwattConfig;
@@ -73,5 +119,24 @@ export interface ResolvedNeuralwattConfig {
   };
   subBarIntegration: {
     enabled: boolean;
+  };
+  allowances: {
+    enabled: boolean;
+    session: {
+      enabled: boolean;
+      allowanceUsd?: number;
+    };
+    request: {
+      enabled: boolean;
+      allowanceUsd?: number;
+    };
+    widget: {
+      enabled: boolean;
+      placement: NeuralwattWidgetPlacement;
+    };
+    warnings: {
+      enabled: boolean;
+      remainingThresholds: number[];
+    };
   };
 }

--- a/src/events.test.ts
+++ b/src/events.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { parseAllowanceHeaders } from "./events";
+
+describe("parseAllowanceHeaders", () => {
+  it("returns undefined when no session allowance headers are present", () => {
+    expect(parseAllowanceHeaders({})).toBeUndefined();
+    expect(
+      parseAllowanceHeaders({ "x-request-cost-usd": "0.01" }),
+    ).toBeUndefined();
+  });
+
+  it("parses session allowance headers case-insensitively", () => {
+    expect(
+      parseAllowanceHeaders({
+        "X-Session-Spent-USD": "0.12",
+        "x-session-allowance-remaining-usd": "0.88",
+      }),
+    ).toEqual({
+      sessionSpentUsd: 0.12,
+      sessionAllowanceRemainingUsd: 0.88,
+    });
+  });
+
+  it("uses null remaining when no remaining header is present", () => {
+    expect(parseAllowanceHeaders({ "X-Session-Spent-USD": "0.12" })).toEqual({
+      sessionSpentUsd: 0.12,
+      sessionAllowanceRemainingUsd: null,
+    });
+  });
+
+  it("ignores invalid session-spent header values", () => {
+    expect(
+      parseAllowanceHeaders({ "X-Session-Spent-USD": "nope" }),
+    ).toBeUndefined();
+  });
+});

--- a/src/events.ts
+++ b/src/events.ts
@@ -21,6 +21,9 @@ export const NEURALWATT_QUOTAS_UPDATED_EVENT =
 export const NEURALWATT_QUOTAS_REQUEST_EVENT =
   "neuralwatt:quotas:request" as const;
 
+export const NEURALWATT_ALLOWANCES_UPDATED_EVENT =
+  "neuralwatt:allowances:updated" as const;
+
 export interface NeuralwattExtensionsRegisterPayload {
   feature: NeuralwattFeatureId;
 }
@@ -36,6 +39,19 @@ export interface NeuralwattQuotasUpdatedPayload {
   source: QuotaSource;
 }
 
+export interface NeuralwattHeaderAllowances {
+  sessionSpentUsd: number;
+  sessionAllowanceRemainingUsd: number | null;
+}
+
+export interface NeuralwattAllowancesUpdatedPayload
+  extends NeuralwattHeaderAllowances {
+  sessionId: string;
+  sessionAllowanceUsd: number | null;
+  requestAllowanceUsd: number | null;
+  updatedAt: string;
+}
+
 /** Minimal quota data parsed from response headers */
 export interface NeuralwattHeaderQuotas {
   allowanceRemainingUsd: number;
@@ -49,36 +65,54 @@ export interface NeuralwattHeaderQuotas {
 }
 
 /** Parse Neuralwatt quota headers from after_provider_response */
+function getHeader(
+  headers: Record<string, string>,
+  name: string,
+): string | undefined {
+  const entry = Object.entries(headers).find(
+    ([key]) => key.toLowerCase() === name.toLowerCase(),
+  );
+  return entry?.[1];
+}
+
+function tryFloat(v: string | undefined): number | undefined {
+  if (v === undefined) return undefined;
+  const n = Number.parseFloat(v);
+  return Number.isFinite(n) ? n : undefined;
+}
+
+function safeFloat(v: string | undefined, fallback = 0): number {
+  return tryFloat(v) ?? fallback;
+}
+
 export function parseQuotaHeaders(
   headers: Record<string, string>,
 ): NeuralwattHeaderQuotas | undefined {
-  const get = (name: string): string | undefined => {
-    const entry = Object.entries(headers).find(
-      ([key]) => key.toLowerCase() === name.toLowerCase(),
-    );
-    return entry?.[1];
-  };
-
-  const remaining = get("x-allowance-remaining-usd");
+  const remaining = getHeader(headers, "x-allowance-remaining-usd");
   if (!remaining) return undefined;
-
-  const tryFloat = (v: string | undefined): number | undefined => {
-    if (v === undefined) return undefined;
-    const n = Number.parseFloat(v);
-    return Number.isFinite(n) ? n : undefined;
-  };
-
-  const safeFloat = (v: string | undefined, fallback = 0): number =>
-    tryFloat(v) ?? fallback;
 
   return {
     allowanceRemainingUsd: safeFloat(remaining),
-    budgetRemainingUsd: safeFloat(get("x-budget-remaining-usd")),
-    requestCostUsd: safeFloat(get("x-request-cost-usd")),
-    cacheSavingsUsd: safeFloat(get("x-cache-savings-usd")),
-    subscriptionPlan: get("x-subscription-plan") ?? "none",
-    energyIncluded: tryFloat(get("x-energy-included")),
-    energyRemaining: tryFloat(get("x-energy-remaining")),
-    energyUsed: tryFloat(get("x-energy-used")),
+    budgetRemainingUsd: safeFloat(getHeader(headers, "x-budget-remaining-usd")),
+    requestCostUsd: safeFloat(getHeader(headers, "x-request-cost-usd")),
+    cacheSavingsUsd: safeFloat(getHeader(headers, "x-cache-savings-usd")),
+    subscriptionPlan: getHeader(headers, "x-subscription-plan") ?? "none",
+    energyIncluded: tryFloat(getHeader(headers, "x-energy-included")),
+    energyRemaining: tryFloat(getHeader(headers, "x-energy-remaining")),
+    energyUsed: tryFloat(getHeader(headers, "x-energy-used")),
+  };
+}
+
+/** Parse Neuralwatt allowance headers from after_provider_response. */
+export function parseAllowanceHeaders(
+  headers: Record<string, string>,
+): NeuralwattHeaderAllowances | undefined {
+  const spent = tryFloat(getHeader(headers, "x-session-spent-usd"));
+  if (spent === undefined) return undefined;
+
+  return {
+    sessionSpentUsd: spent,
+    sessionAllowanceRemainingUsd:
+      tryFloat(getHeader(headers, "x-session-allowance-remaining-usd")) ?? null,
   };
 }


### PR DESCRIPTION
## Summary
- add hidden Neuralwatt request/session allowance config
- add `/neuralwatt:allowances` using the shared settings UI
- inject allowance request headers through Pi 0.80.8's typed `before_provider_headers` hook
- parse allowance response headers and expose widget/warnings
- show effective project override values while editing global defaults

## Checks
- `pnpm typecheck`
- `pnpm lint`
- `pnpm check:schema`
- `pnpm check:lockfile`
- offline Vitest suite: 55 tests passed

## Manual verification
- live allowance request enforcement and response headers remain for manual E2E testing