### PR TITLE
feat: add /neuralwatt:flex command

### DIFF
--- a/.changeset/neuralwatt-flex-command.md
+++ b/.changeset/neuralwatt-flex-command.md
@@ -1,0 +1,11 @@
+---
+"@aliou/pi-neuralwatt": minor
+---
+
+Add `/neuralwatt:flex` command for per-session Flex tier configuration.
+
+The new command lets users toggle Neuralwatt's Flex tier and configure a custom
+timeout for the current session. When Flex is enabled, `service_tier: "flex"`
+is injected into outgoing Neuralwatt requests and the request timeout is
+extended. The timeout is also extended automatically for model IDs ending in
+`-flex`.

--- a/extensions/provider/commands/flex/components/flex-config-display.ts
+++ b/extensions/provider/commands/flex/components/flex-config-display.ts
@@ -1,0 +1,129 @@
+import { Panel } from "@aliou/pi-utils-ui";
+import type { Theme } from "@earendil-works/pi-coding-agent";
+import {
+  type Component,
+  Input,
+  type SettingItem,
+  SettingsList,
+  type TUI,
+} from "@earendil-works/pi-tui";
+import { formatDuration, parseDuration } from "../../../../../src/duration";
+import type { FlexSessionState } from "../../../../../src/flex-session";
+
+function buildTimeoutSubmenu(
+  theme: Theme,
+  currentValue: string,
+  done: (value?: string) => void,
+): Component {
+  const initialMs = parseDuration(currentValue, "m") ?? 30 * 60 * 1000;
+  const input = new Input();
+  const initialValue = formatDuration(initialMs);
+  input.setValue(initialValue);
+  (input as unknown as { cursor: number }).cursor = initialValue.length;
+  input.onSubmit = () => {
+    const ms = parseDuration(input.getValue(), "m");
+    if (ms !== undefined && ms > 0) {
+      done(formatDuration(ms));
+    }
+  };
+  input.onEscape = () => done();
+
+  return {
+    render: (width: number) => {
+      const lines: string[] = [];
+      lines.push(theme.fg("text", "  Timeout in minutes (e.g. 30, 30m, 1h):"));
+      lines.push(...input.render(width));
+      lines.push("");
+      lines.push(theme.fg("dim", "  Presets: 5m, 15m, 30m, 1h, 2h"));
+      return lines;
+    },
+    handleInput: (data: string) => {
+      input.focused = true;
+      input.handleInput(data);
+    },
+    invalidate: () => {},
+  };
+}
+
+export class FlexConfigComponent implements Component {
+  private panel: Panel;
+  private settings: SettingsList;
+
+  constructor(
+    theme: Theme,
+    tui: TUI,
+    initial: FlexSessionState,
+    onChange: (state: FlexSessionState) => void,
+    onClose: () => void,
+  ) {
+    const state: FlexSessionState = { ...initial };
+
+    const items: SettingItem[] = [
+      {
+        id: "enabled",
+        label: "Enabled",
+        currentValue: state.enabled ? "on" : "off",
+        values: ["on", "off"],
+        description:
+          "Toggle Flex tier for this session. When on, service_tier is sent as flex.",
+      },
+      {
+        id: "timeout",
+        label: "Timeout",
+        currentValue: formatDuration(state.timeoutMs),
+        description:
+          "How long to wait for a Flex request before the client aborts.",
+        submenu: (currentValue, done) =>
+          buildTimeoutSubmenu(theme, currentValue, done),
+      },
+    ];
+
+    this.settings = new SettingsList(
+      items,
+      5,
+      {
+        label: (text, selected) =>
+          selected
+            ? theme.fg("accent", theme.bold(text))
+            : theme.fg("text", text),
+        value: (text, selected) =>
+          selected ? theme.fg("accent", text) : theme.fg("muted", text),
+        description: (text) => theme.fg("dim", text),
+        cursor: theme.fg("accent", "> "),
+        hint: (text) => theme.fg("dim", text),
+      },
+      (id, value) => {
+        if (id === "enabled") {
+          state.enabled = value === "on";
+        } else if (id === "timeout") {
+          const ms = parseDuration(value);
+          if (ms !== undefined && ms > 0) {
+            state.timeoutMs = ms;
+          }
+        }
+        onChange({ ...state });
+        tui.requestRender();
+      },
+      onClose,
+    );
+
+    this.panel = new Panel({
+      title: "Neuralwatt Flex Mode",
+      body: this.settings,
+      borderStyle: (s) => theme.fg("border", s),
+      titleStyle: (s) => theme.fg("accent", theme.bold(s)),
+    });
+  }
+
+  render(width: number): string[] {
+    return this.panel.render(width);
+  }
+
+  handleInput(data: string): void {
+    this.settings.handleInput(data);
+  }
+
+  invalidate(): void {
+    this.panel.invalidate();
+  }
+}

--- a/extensions/provider/commands/flex/index.ts
+++ b/extensions/provider/commands/flex/index.ts
@@ -1,0 +1,138 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import type { AutocompleteItem } from "@earendil-works/pi-tui";
+import { formatDuration, parseDuration } from "../../../../src/duration";
+import { NEURALWATT_FLEX_UPDATED_EVENT } from "../../../../src/events";
+import {
+  type FlexSessionState,
+  getFlexSessionState,
+  setFlexEnabled,
+  setFlexTimeoutMs,
+} from "../../../../src/flex-session";
+import { FlexConfigComponent } from "./components/flex-config-display";
+
+type Notify = (message: string, type: "info" | "error" | "warning") => void;
+
+function formatState(state: FlexSessionState): string {
+  return `Flex: ${state.enabled ? "on" : "off"}, timeout: ${formatDuration(state.timeoutMs)}`;
+}
+
+function emitFlexUpdated(pi: ExtensionAPI): void {
+  const state = getFlexSessionState();
+  pi.events.emit(NEURALWATT_FLEX_UPDATED_EVENT, {
+    enabled: state.enabled,
+    timeoutMs: state.timeoutMs,
+  });
+}
+
+function applyArgs(tokens: string[], notify: Notify, pi: ExtensionAPI): void {
+  const sub = tokens[0];
+
+  if (!sub || sub === "status") {
+    notify(formatState(getFlexSessionState()), "info");
+    return;
+  }
+
+  if (sub === "on") {
+    setFlexEnabled(true);
+    emitFlexUpdated(pi);
+    notify(formatState(getFlexSessionState()), "info");
+    return;
+  }
+
+  if (sub === "off") {
+    setFlexEnabled(false);
+    emitFlexUpdated(pi);
+    notify(formatState(getFlexSessionState()), "info");
+    return;
+  }
+
+  if (sub === "timeout") {
+    const raw = tokens[1];
+    if (!raw) {
+      notify("Usage: /neuralwatt:flex timeout <duration>", "error");
+      return;
+    }
+    if (tokens.length > 2) {
+      notify(
+        "Too many arguments. Usage: /neuralwatt:flex timeout <duration>",
+        "error",
+      );
+      return;
+    }
+    const ms = parseDuration(raw);
+    if (ms === undefined || ms <= 0) {
+      notify(`Invalid timeout: ${raw}. Use e.g. 30m, 1h, 1800000.`, "error");
+      return;
+    }
+    setFlexTimeoutMs(ms);
+    emitFlexUpdated(pi);
+    notify(formatState(getFlexSessionState()), "info");
+    return;
+  }
+
+  notify(
+    `Unknown option: ${sub}. Use on, off, timeout <duration>, or status.`,
+    "error",
+  );
+}
+
+function getCompletions(prefix: string): AutocompleteItem[] | null {
+  const tokens = prefix.trim().split(/\s+/);
+  const first = tokens[0] ?? "";
+  const isFirstComplete = !prefix.endsWith(" ") && tokens.length === 1;
+
+  if (tokens.length === 0 || (tokens.length === 1 && isFirstComplete)) {
+    const options = ["on", "off", "timeout", "status"];
+    return options
+      .filter((o) => o.startsWith(first))
+      .map((o) => ({ value: o, label: o }));
+  }
+
+  if (tokens[0] === "timeout") {
+    const second = tokens[1] ?? "";
+    const durations = ["5m", "15m", "30m", "1h", "2h"];
+    return durations
+      .filter((d) => d.startsWith(second))
+      .map((d) => ({ value: d, label: d }));
+  }
+
+  return null;
+}
+
+export function registerFlexCommand(pi: ExtensionAPI): void {
+  pi.registerCommand("neuralwatt:flex", {
+    description: "Configure Neuralwatt Flex tier for this session",
+    getArgumentCompletions: (prefix) => getCompletions(prefix),
+    handler: async (args, ctx) => {
+      const trimmed = args.trim();
+
+      if (trimmed.length > 0) {
+        const tokens = trimmed.split(/\s+/);
+        applyArgs(tokens, (msg, type) => ctx.ui.notify(msg, type), pi);
+        return;
+      }
+
+      const initial = { ...getFlexSessionState() };
+
+      const result = await ctx.ui.custom<null>(
+        (tui, theme, _keybindings, done) => {
+          return new FlexConfigComponent(
+            theme,
+            tui,
+            initial,
+            (state) => {
+              setFlexEnabled(state.enabled);
+              setFlexTimeoutMs(state.timeoutMs);
+              emitFlexUpdated(pi);
+            },
+            () => done(null),
+          );
+        },
+      );
+
+      if (result === undefined) {
+        ctx.ui.notify(formatState(getFlexSessionState()), "info");
+      }
+    },
+  });
+}

--- a/extensions/provider/index.ts
+++ b/extensions/provider/index.ts
@@ -1,21 +1,30 @@
 import { getApiProvider } from "@earendil-works/pi-ai/compat";
 import type {
   ExtensionAPI,
+  ExtensionContext,
   ModelRegistry,
+  ProviderModelConfig,
 } from "@earendil-works/pi-coding-agent";
 import { configLoader } from "../../src/config";
 import {
   NEURALWATT_CONFIG_UPDATED_EVENT,
   NEURALWATT_EXTENSIONS_REGISTER_EVENT,
   NEURALWATT_EXTENSIONS_REQUEST_EVENT,
+  NEURALWATT_FLEX_UPDATED_EVENT,
   NEURALWATT_QUOTAS_REQUEST_EVENT,
   NEURALWATT_QUOTAS_UPDATED_EVENT,
   type NeuralwattFeatureId,
+  type NeuralwattFlexUpdatedPayload,
   type NeuralwattQuotasUpdatedPayload,
 } from "../../src/events";
+import {
+  getFlexSessionState,
+  resetFlexSessionState,
+} from "../../src/flex-session";
 import { fetchQuotas } from "../../src/lib/neuralwatt-api";
 import type { NeuralwattQuotas } from "../../src/types/quota-api";
 import { getNeuralwattApiKey } from "../_shared/auth";
+import { registerFlexCommand } from "./commands/flex";
 import { registerNeuralwattSettings } from "./commands/settings";
 import { normalizeNeuralwattContextOverflowError } from "./context-overflow";
 import { getNeuralwattModels, refreshNeuralwattModels } from "./models";
@@ -29,11 +38,46 @@ import { updateQuotasFromSseComment } from "./sse-quotas";
 import { wrapNeuralwattStreamSimple } from "./stream-simple";
 
 const HEADER_EMIT_THROTTLE_MS = 5_000;
+const FLEX_STATUS_KEY = "neuralwatt:flex";
+
+let flexModelIds = new Set<string>();
+let currentFlexCtx: ExtensionContext | undefined;
+let currentFlexModelId: string | undefined;
 
 function emitConfigUpdated(pi: ExtensionAPI): void {
   pi.events.emit(NEURALWATT_CONFIG_UPDATED_EVENT, {
     config: configLoader.getConfig(),
   });
+}
+
+function updateFlexModelIds(models: ProviderModelConfig[]): void {
+  flexModelIds = new Set(models.map((m) => m.id));
+}
+
+function modelSupportsFlex(modelId: string): boolean {
+  if (modelId.endsWith("-flex")) return true;
+  return flexModelIds.has(`${modelId}-flex`);
+}
+
+function updateFlexStatus(): void {
+  const ctx = currentFlexCtx;
+  if (!ctx?.hasUI) return;
+
+  const state = getFlexSessionState();
+  const provider = ctx.model?.provider;
+  const modelId = currentFlexModelId ?? ctx.model?.id;
+
+  const shouldShow =
+    state.enabled &&
+    provider === "neuralwatt" &&
+    modelId !== undefined &&
+    modelSupportsFlex(modelId);
+
+  if (shouldShow) {
+    ctx.ui.setStatus(FLEX_STATUS_KEY, ctx.ui.theme.fg("accent", "flex: on"));
+  } else {
+    ctx.ui.setStatus(FLEX_STATUS_KEY, undefined);
+  }
 }
 
 function registerNeuralwattProvider(
@@ -76,6 +120,7 @@ function registerNeuralwattProvider(
   }
 
   pi.registerProvider("neuralwatt", config);
+  updateFlexModelIds(config.models ?? []);
 }
 
 export default async function (pi: ExtensionAPI) {
@@ -108,6 +153,9 @@ export default async function (pi: ExtensionAPI) {
     getLoadedFeatures: () => loadedFeatures,
   });
 
+  // Register the per-session Flex tier command.
+  registerFlexCommand(pi);
+
   pi.events.on(NEURALWATT_CONFIG_UPDATED_EVENT, () => {
     const next = configLoader.getConfig().provider;
     if (
@@ -120,6 +168,24 @@ export default async function (pi: ExtensionAPI) {
     }
     registeredProviderSettings = { ...next };
     registerNeuralwattProvider(pi, handleSseQuota);
+  });
+
+  pi.on("model_select", async (_event, ctx) => {
+    currentFlexCtx = ctx;
+    currentFlexModelId = ctx.model?.id;
+    updateFlexStatus();
+  });
+
+  pi.on("session_before_switch", (_event, ctx) => {
+    currentFlexCtx = ctx;
+    currentFlexModelId = ctx.model?.id;
+    updateFlexStatus();
+  });
+
+  pi.events.on(NEURALWATT_FLEX_UPDATED_EVENT, (data: unknown) => {
+    const payload = data as NeuralwattFlexUpdatedPayload;
+    if (!payload || typeof payload !== "object") return;
+    updateFlexStatus();
   });
 
   let lastHeaderEmitAt = 0;
@@ -194,6 +260,18 @@ export default async function (pi: ExtensionAPI) {
     return { message: overflowMessage };
   });
 
+  pi.on("before_provider_request", (event, ctx) => {
+    if (ctx.model?.provider !== "neuralwatt") return;
+
+    const state = getFlexSessionState();
+    if (!state.enabled) return;
+
+    const payload = event.payload as Record<string, unknown> | undefined;
+    if (!payload || payload.service_tier !== undefined) return;
+
+    return { ...payload, service_tier: "flex" };
+  });
+
   pi.on("after_provider_response", (event, ctx) => {
     if (ctx.model?.provider !== "neuralwatt") return;
 
@@ -230,6 +308,10 @@ export default async function (pi: ExtensionAPI) {
 
   pi.on("session_start", async (_event, ctx) => {
     currentModelRegistry = ctx.modelRegistry;
+    resetFlexSessionState();
+    currentFlexCtx = ctx;
+    currentFlexModelId = ctx.model?.id;
+    updateFlexStatus();
     pendingRateLimitInfo = undefined;
     const messages = [...new Set(configLoader.drainMessages())];
     if (messages.length > 0) {
@@ -249,5 +331,7 @@ export default async function (pi: ExtensionAPI) {
 
   pi.on("session_shutdown", () => {
     currentModelRegistry = undefined;
+    currentFlexCtx = undefined;
+    currentFlexModelId = undefined;
   });
 }

--- a/extensions/provider/stream-simple.test.ts
+++ b/extensions/provider/stream-simple.test.ts
@@ -1,6 +1,11 @@
 import { createAssistantMessageEventStream } from "@earendil-works/pi-ai";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  resetFlexSessionState,
+  setFlexEnabled,
+  setFlexTimeoutMs,
+} from "../../src/flex-session";
+import {
   type AnyStreamSimple,
   wrapNeuralwattStreamSimple,
 } from "./stream-simple";
@@ -36,6 +41,7 @@ async function collect(stream: AsyncIterable<unknown>): Promise<unknown[]> {
 afterEach(() => {
   globalThis.fetch = originalFetch;
   vi.restoreAllMocks();
+  resetFlexSessionState();
 });
 
 describe("wrapNeuralwattStreamSimple", () => {
@@ -154,5 +160,53 @@ describe("wrapNeuralwattStreamSimple", () => {
       ': energy {"energy_joules":360000}',
     );
     expect(globalThis.fetch).toBe(fetchMock);
+  });
+
+  it("extends timeout when flex mode is enabled", async () => {
+    setFlexEnabled(true);
+    setFlexTimeoutMs(30 * 60 * 1000);
+
+    const base: AnyStreamSimple = (_model, _context, options) => {
+      const stream = createAssistantMessageEventStream();
+      expect(options?.timeoutMs).toBe(30 * 60 * 1000);
+      queueMicrotask(() => stream.end());
+      return stream;
+    };
+
+    const wrapped = wrapNeuralwattStreamSimple(base, () => {});
+    await collect(wrapped({ id: "glm-5.2" } as never, {} as never));
+  });
+
+  it("extends timeout for -flex model IDs", async () => {
+    setFlexTimeoutMs(45 * 60 * 1000);
+
+    const base: AnyStreamSimple = (_model, _context, options) => {
+      const stream = createAssistantMessageEventStream();
+      expect(options?.timeoutMs).toBe(45 * 60 * 1000);
+      queueMicrotask(() => stream.end());
+      return stream;
+    };
+
+    const wrapped = wrapNeuralwattStreamSimple(base, () => {});
+    await collect(wrapped({ id: "glm-5.2-flex" } as never, {} as never));
+  });
+
+  it("does not reduce an already longer timeout", async () => {
+    setFlexEnabled(true);
+    setFlexTimeoutMs(30 * 60 * 1000);
+
+    const base: AnyStreamSimple = (_model, _context, options) => {
+      const stream = createAssistantMessageEventStream();
+      expect(options?.timeoutMs).toBe(60 * 60 * 1000);
+      queueMicrotask(() => stream.end());
+      return stream;
+    };
+
+    const wrapped = wrapNeuralwattStreamSimple(base, () => {});
+    await collect(
+      wrapped({ id: "glm-5.2" } as never, {} as never, {
+        timeoutMs: 60 * 60 * 1000,
+      }),
+    );
   });
 });

--- a/extensions/provider/stream-simple.ts
+++ b/extensions/provider/stream-simple.ts
@@ -14,12 +14,31 @@ import {
   type Model,
   type SimpleStreamOptions,
 } from "@earendil-works/pi-ai";
+import { getFlexSessionState } from "../../src/flex-session";
 import {
   type NeuralwattRateLimitInfo,
   normalizeNeuralwattRateLimitError,
   parseRateLimitHeaders,
 } from "./rate-limit-error";
 import { readQuotaCommentsFromTee } from "./sse-quotas";
+
+function shouldUseFlexTimeout(model: Model<string>): boolean {
+  const state = getFlexSessionState();
+  if (state.enabled) return true;
+  if (model.id?.endsWith("-flex")) return true;
+  return false;
+}
+
+function applyFlexTimeout(
+  model: Model<string>,
+  options: SimpleStreamOptions,
+): void {
+  const state = getFlexSessionState();
+  if (!shouldUseFlexTimeout(model)) return;
+  if (options.timeoutMs !== undefined && options.timeoutMs >= state.timeoutMs)
+    return;
+  options.timeoutMs = state.timeoutMs;
+}
 
 export type AnyStreamSimple = (
   model: Model<string>,
@@ -86,6 +105,7 @@ export function wrapNeuralwattStreamSimple(
   onSseQuota: (line: string) => void,
 ): AnyStreamSimple {
   return (model, context, options = {}) => {
+    applyFlexTimeout(model, options);
     let rateLimitInfo: NeuralwattRateLimitInfo | undefined;
     let sseQuotaTask: Promise<void> | undefined;
     const outer = createAssistantMessageEventStream();

--- a/src/duration.test.ts
+++ b/src/duration.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { formatDuration, parseDuration } from "./duration";
+
+describe("parseDuration", () => {
+  it("parses milliseconds by default", () => {
+    expect(parseDuration("30000")).toBe(30000);
+  });
+
+  it("parses seconds", () => {
+    expect(parseDuration("30s")).toBe(30000);
+    expect(parseDuration("30S")).toBe(30000);
+    expect(parseDuration("30 sec")).toBe(30000);
+  });
+
+  it("parses minutes", () => {
+    expect(parseDuration("30m")).toBe(30 * 60 * 1000);
+    expect(parseDuration("30M")).toBe(30 * 60 * 1000);
+    expect(parseDuration("30 min")).toBe(30 * 60 * 1000);
+  });
+
+  it("parses hours", () => {
+    expect(parseDuration("2h")).toBe(2 * 60 * 60 * 1000);
+    expect(parseDuration("2H")).toBe(2 * 60 * 60 * 1000);
+    expect(parseDuration("2 hr")).toBe(2 * 60 * 60 * 1000);
+  });
+
+  it("handles decimal values", () => {
+    expect(parseDuration("1.5h")).toBe(1.5 * 60 * 60 * 1000);
+    expect(parseDuration("0.5m")).toBe(0.5 * 60 * 1000);
+  });
+
+  it("returns undefined for invalid input", () => {
+    expect(parseDuration("")).toBeUndefined();
+    expect(parseDuration("abc")).toBeUndefined();
+    expect(parseDuration("-5m")).toBeUndefined();
+    expect(parseDuration("0m")).toBeUndefined();
+  });
+
+  it("uses the default unit when no unit is provided", () => {
+    expect(parseDuration("30", "m")).toBe(30 * 60 * 1000);
+    expect(parseDuration("30", "s")).toBe(30 * 1000);
+    expect(parseDuration("30", "h")).toBe(30 * 60 * 60 * 1000);
+    expect(parseDuration("30")).toBe(30);
+  });
+});
+
+describe("formatDuration", () => {
+  it("formats seconds", () => {
+    expect(formatDuration(30 * 1000)).toBe("30s");
+  });
+
+  it("formats minutes", () => {
+    expect(formatDuration(30 * 60 * 1000)).toBe("30m");
+  });
+
+  it("formats hours", () => {
+    expect(formatDuration(2 * 60 * 60 * 1000)).toBe("2h");
+  });
+
+  it("formats hours and minutes", () => {
+    expect(formatDuration(90 * 60 * 1000)).toBe("1h 30m");
+  });
+});

--- a/src/duration.ts
+++ b/src/duration.ts
@@ -1,0 +1,35 @@
+export type DurationUnit = "ms" | "s" | "m" | "h";
+
+export function parseDuration(
+  input: string,
+  defaultUnit: DurationUnit = "ms",
+): number | undefined {
+  const match = input
+    .trim()
+    .match(/^(\d+(?:\.\d+)?)\s*(ms|s|sec|m|min|h|hr)?$/i);
+  if (!match) return undefined;
+  const value = Number.parseFloat(match[1]);
+  if (!Number.isFinite(value) || value <= 0) return undefined;
+  const unit = (match[2] ? normalizeUnit(match[2]) : defaultUnit).toLowerCase();
+  if (unit === "s") return Math.round(value * 1000);
+  if (unit === "m") return Math.round(value * 60 * 1000);
+  if (unit === "h") return Math.round(value * 60 * 60 * 1000);
+  return Math.round(value);
+}
+
+function normalizeUnit(unit: string): DurationUnit {
+  const lower = unit.toLowerCase();
+  if (lower === "sec") return "s";
+  if (lower === "min") return "m";
+  if (lower === "hr") return "h";
+  return lower as DurationUnit;
+}
+
+export function formatDuration(ms: number): string {
+  if (ms < 60 * 1000) return `${Math.round(ms / 1000)}s`;
+  if (ms < 60 * 60 * 1000) return `${Math.round(ms / 60 / 1000)}m`;
+  const hours = Math.floor(ms / 60 / 60 / 1000);
+  const minutes = Math.round((ms % (60 * 60 * 1000)) / 60 / 1000);
+  if (minutes === 0) return `${hours}h`;
+  return `${hours}h ${minutes}m`;
+}

--- a/src/events.ts
+++ b/src/events.ts
@@ -21,6 +21,8 @@ export const NEURALWATT_QUOTAS_UPDATED_EVENT =
 export const NEURALWATT_QUOTAS_REQUEST_EVENT =
   "neuralwatt:quotas:request" as const;
 
+export const NEURALWATT_FLEX_UPDATED_EVENT = "neuralwatt:flex:updated" as const;
+
 export interface NeuralwattExtensionsRegisterPayload {
   feature: NeuralwattFeatureId;
 }
@@ -34,6 +36,11 @@ export type QuotaSource = "header" | "api" | "sse";
 export interface NeuralwattQuotasUpdatedPayload {
   quotas: NeuralwattQuotas;
   source: QuotaSource;
+}
+
+export interface NeuralwattFlexUpdatedPayload {
+  enabled: boolean;
+  timeoutMs: number;
 }
 
 /** Minimal quota data parsed from response headers */

--- a/src/flex-session.ts
+++ b/src/flex-session.ts
@@ -1,0 +1,27 @@
+export interface FlexSessionState {
+  enabled: boolean;
+  timeoutMs: number;
+}
+
+const DEFAULT_FLEX_TIMEOUT_MS = 30 * 60 * 1000;
+
+let state: FlexSessionState = {
+  enabled: false,
+  timeoutMs: DEFAULT_FLEX_TIMEOUT_MS,
+};
+
+export function getFlexSessionState(): Readonly<FlexSessionState> {
+  return state;
+}
+
+export function setFlexEnabled(enabled: boolean): void {
+  state.enabled = enabled;
+}
+
+export function setFlexTimeoutMs(timeoutMs: number): void {
+  state.timeoutMs = timeoutMs;
+}
+
+export function resetFlexSessionState(): void {
+  state = { enabled: false, timeoutMs: DEFAULT_FLEX_TIMEOUT_MS };
+}


### PR DESCRIPTION
Adds a per-session `/neuralwatt:flex` command that toggles Neuralwatt's Flex tier and configures a custom timeout.

When Flex is enabled, outgoing Neuralwatt requests get `service_tier: "flex"` injected and the request timeout is extended. A `flex: on` status indicator is shown when the current model supports Flex.

Includes duration parsing helpers and tests.