### PR TITLE
feat: expose max thinking level for GLM-5.2 models

### DIFF
--- a/.agents/skills/neuralwatt-models/SKILL.md
+++ b/.agents/skills/neuralwatt-models/SKILL.md
@@ -138,6 +138,7 @@ thinkingLevelMap: {
   medium: "medium",
   high: "high",
   xhigh: null,
+  max: null,
 },
 ```
 
@@ -150,8 +151,25 @@ thinkingLevelMap: {
   medium: "medium",
   high: null,
   xhigh: null,
+  max: null,
 },
 ```
+
+For models that expose a top `max` provider tier above `high` without a distinct `xhigh` (e.g. GLM-5.2, which natively supports `high` and `max` reasoning efforts), map Pi's `max` level to the provider's `max` value and leave `xhigh` as an unsupported hole. Pi introduced the `max` thinking level in 0.80.6:
+
+```ts
+thinkingLevelMap: {
+  off: "none",
+  minimal: null,
+  low: null,
+  medium: null,
+  high: "high",
+  xhigh: null,
+  max: "max",
+},
+```
+
+Omitting `max` (or any extended level) marks it unsupported. Only set `max` to a non-null provider value when the model actually distinguishes a top reasoning tier.
 
 ## Decision rules
 

--- a/.changeset/max-thinking-level.md
+++ b/.changeset/max-thinking-level.md
@@ -1,0 +1,5 @@
+---
+"@aliou/pi-neuralwatt": minor
+---
+
+Expose Pi's `max` thinking level (introduced in Pi 0.80.6) on GLM-5.2 reasoning models. GLM-5.2 natively supports `high` and `max` reasoning efforts, so Pi's `max` level now maps directly to the provider's `max` value; `xhigh` is marked as an unsupported hole between `high` and `max`. Verified `reasoning_effort: "max"` against the Neuralwatt API (glm-5.2 produces extended thinking). Peer dependency range tightened to `>=0.80.6` for the Pi core packages since the source now references the `max` thinking level.

--- a/extensions/provider/models.test.ts
+++ b/extensions/provider/models.test.ts
@@ -320,4 +320,21 @@ describe("Neuralwatt models", () => {
       expect(model.thinkingLevelMap).toHaveProperty("xhigh");
     }
   });
+
+  it("should expose the Pi `max` thinking level on GLM reasoning models", () => {
+    // GLM-5.2 natively supports `high` and `max` reasoning efforts. Pi's `max`
+    // level (introduced in 0.80.6) maps to GLM's top tier; `xhigh` is an
+    // unsupported hole between `high` and `max`.
+    const glmModels = NEURALWATT_MODELS.filter((m) =>
+      m.id.startsWith("glm-5.2"),
+    ).filter((m) => m.reasoning);
+
+    expect(glmModels.length).toBeGreaterThan(0);
+    for (const model of glmModels) {
+      expect(model.thinkingLevelMap).toHaveProperty("max");
+      expect(model.thinkingLevelMap?.max).toBe("max");
+      expect(model.thinkingLevelMap?.xhigh).toBeNull();
+      expect(model.thinkingLevelMap?.high).toBe("high");
+    }
+  });
 });

--- a/extensions/provider/models/public-models.ts
+++ b/extensions/provider/models/public-models.ts
@@ -4,6 +4,9 @@ import type { ProviderModelConfig } from "@earendil-works/pi-coding-agent";
 // Pricing, capabilities, and limits are sourced from the API metadata fields.
 export const NEURALWATT_MODELS: ProviderModelConfig[] = [
   // GLM-5.2 - ZhipuAI
+  // Native reasoning tiers: off (none), high, max. Exposes Pi's `max` level
+  // (introduced in Pi 0.80.6) for GLM's top tier; `xhigh` is an unsupported
+  // hole between `high` and `max`.
   {
     id: "glm-5.2",
     name: "GLM-5.2",
@@ -23,7 +26,8 @@ export const NEURALWATT_MODELS: ProviderModelConfig[] = [
       low: null,
       medium: null,
       high: "high",
-      xhigh: "max",
+      xhigh: null,
+      max: "max",
     },
     compat: {
       supportsDeveloperRole: false,
@@ -70,7 +74,8 @@ export const NEURALWATT_MODELS: ProviderModelConfig[] = [
       low: null,
       medium: null,
       high: "high",
-      xhigh: "max",
+      xhigh: null,
+      max: "max",
     },
     compat: {
       supportsDeveloperRole: false,
@@ -283,7 +288,8 @@ export const NEURALWATT_MODELS: ProviderModelConfig[] = [
       low: null,
       medium: null,
       high: "high",
-      xhigh: "max",
+      xhigh: null,
+      max: "max",
     },
     compat: {
       supportsDeveloperRole: false,
@@ -366,7 +372,8 @@ export const NEURALWATT_MODELS: ProviderModelConfig[] = [
       low: null,
       medium: null,
       high: "high",
-      xhigh: "max",
+      xhigh: null,
+      max: "max",
     },
     compat: {
       supportsDeveloperRole: false,


### PR DESCRIPTION
> [!NOTE]
> This pull request was opened by Pi (glm-5.2).

## Summary

Exposes Pi's `max` thinking level (introduced in Pi 0.80.6, stabilized in 0.80.7) on GLM-5.2 reasoning models in the pi-neuralwatt provider.

## Changes

GLM-5.2 natively supports `high` and `max` reasoning efforts. The previous config mapped Pi's old top level (`xhigh`) to GLM's `max` value. With Pi 0.80.6 adding a dedicated `max` level above `xhigh`, this moves the mapping where it belongs:

- `extensions/provider/models/public-models.ts`: for `glm-5.2`, `glm-5.2-short`, `glm-5.2-short-flex`, `glm-5.2-flex`, change `xhigh: "max"` to `xhigh: null, max: "max"`. `xhigh` is now an explicit unsupported hole between `high` and `max`, matching Pi's own 0.80.7 catalog pattern and the docs example.
- `extensions/provider/models.test.ts`: added a test asserting GLM reasoning models expose `max: "max"` with `xhigh: null` and `high: "high"`.
- `package.json`: require and validate against Pi `>=0.80.8`, which includes the dedicated `max` thinking level.
- `.agents/skills/neuralwatt-models/SKILL.md`: updated `thinkingLevelMap` examples to include `max` guidance.
- `.changeset/max-thinking-level.md`: minor bump changeset.

## Verification

- `pnpm typecheck` — clean
- `pnpm lint` — clean (45 files)
- `pnpm test` — 39/39 passing after rebasing onto Pi 0.80.8 (including live API model sync)
- Runtime: sent `reasoning_effort: "max"` to `glm-5.2`, `glm-5.2-short` via the Neuralwatt API — both produce extended thinking as expected.

Also probed `max` against the other reasoning models (`kimi-k2.6`, `kimi-k2.7-code`, `qwen3.5-397b`, `qwen3.6-35b`). The Kimi/Qwen3.5 models accept the value but their metadata marks `reasoning_effort: false` (no documented distinct tiers), so they are intentionally left with `max` omitted. `qwen3.6-35b` hard-rejects `max` with a 400.

## Changeset

`@aliou/pi-neuralwatt`: minor

