### PR TITLE
Fix Neuralwatt model output limits and flex pricing

### DIFF
--- a/.agents/skills/neuralwatt-models/SKILL.md
+++ b/.agents/skills/neuralwatt-models/SKILL.md
@@ -7,6 +7,15 @@ description: Update public or hidden model metadata for the pi-neuralwatt extens
 
 Update `extensions/provider/models/public-models.ts` from live Neuralwatt data, not guesswork.
 
+`public-models.ts` is a declarative family/variant table. Each family holds the
+shared pricing, modalities, and `thinkingLevelMap`; each variant (`-fast`,
+`-flex`, `-short`, ...) only declares `id`, `name`, `contextWindow`,
+`maxOutputTokens`, `reasoning`, and any override. `buildNeuralwattModel` in
+`extensions/provider/models/build.ts` turns those into `ProviderModelConfig`
+values and is shared with hidden model discovery, so the compat defaults and the
+`maxTokens` rule live in exactly one place. Add variants to the existing family
+rather than copying a full model literal.
+
 ## Default behavior
 
 Take initiative.
@@ -109,7 +118,7 @@ From `metadata.capabilities`:
 - `developer_role` -> confirm `supportsDeveloperRole: false`
 
 From `metadata.limits`:
-- `max_output_tokens` -> `maxTokens` (null = use default 65536)
+- `max_output_tokens` -> `maxTokens` (null = use `max_model_len`, i.e. the full context window; never invent a cap)
 
 From `metadata`:
 - `display_name` -> `name`
@@ -178,7 +187,7 @@ Omitting `max` (or any extended level) marks it unsupported. Only set `max` to a
 - Remove models only when they are truly gone from Neuralwatt, not because of a temporary fetch issue.
 - Set `contextWindow` from `max_model_len` on the Neuralwatt endpoint.
 - Keep pricing from the portal or existing pricing when the portal has not changed.
-- Keep `maxTokens` from the portal, runtime evidence, or existing conventions when the API does not expose it.
+- Set `maxTokens` to `metadata.limits.max_output_tokens ?? max_model_len`. Use `resolveMaxTokens` in `extensions/provider/models/build.ts`; do not hardcode a fallback.
 - Keep `reasoning`, `input`, and `fast` from portal/runtime evidence or existing conventions when the API does not expose them.
 - Do not add `compat` fields beyond current repo conventions unless live behavior requires it.
 - Do not ask the user which models to update unless there is a true ambiguity you cannot resolve.
@@ -187,7 +196,7 @@ Omitting `max` (or any extended level) marks it unsupported. Only set `max` to a
 
 Use this workflow when a model is available only to authenticated accounts or direct inference requests.
 
-### Choose the hidden-model path
+### Choose the hidden model path
 
 First compare these two requests using the same credential:
 
@@ -201,7 +210,7 @@ Handle the result as follows:
 - If chat completions rejects the model, do not add it. Test likely aliases before concluding that it is unavailable.
 - Never place an API-omitted model in `NEURALWATT_MODELS`. Public definitions are validated against the public catalog and are exposed regardless of `provider.includeHiddenModels`.
 
-`refreshNeuralwattModels` merges hardcoded hidden models with cached and dynamically discovered models for online and offline startup. Public and legacy baseline definitions take precedence over hidden entries. Keep hardcoded hidden IDs unique, and remove or graduate an entry when Neuralwatt starts advertising it publicly.
+`refreshNeuralwattModels` merges hardcoded hidden models with cached and dynamically discovered models for online and offline startup. Public and legacy baseline definitions take precedence over early-access entries. Keep hardcoded early-access IDs unique, and remove or graduate an entry when Neuralwatt starts advertising it publicly.
 
 ### Probe runtime behavior
 
@@ -259,7 +268,7 @@ Read and update:
 - `extensions/provider/models/hidden.ts`
 - `extensions/provider/models/refresh.ts`
 - `extensions/provider/models/refresh.test.ts`
-- `extensions/provider/models/index.ts` when a new hidden-model collection must be exported
+- `extensions/provider/models/index.ts` when a new hidden model collection must be exported
 
 Add tests that prove:
 
@@ -276,7 +285,7 @@ pnpm lint
 pnpm test
 ```
 
-Create a patch changeset for the package and stage only the hidden-model implementation, tests, and changeset.
+Create a patch changeset for the package and stage only the hidden model implementation, tests, and changeset.
 
 ## Required runtime checks
 

--- a/.agents/skills/neuralwatt-models/SKILL.md
+++ b/.agents/skills/neuralwatt-models/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: neuralwatt-models
-description: Update public or hidden model metadata for the pi-neuralwatt extension. Use when adding or refreshing entries in extensions/provider/models/public-models.ts or extensions/provider/models/hidden.ts, checking Neuralwatt model availability, or syncing hardcoded models with the live Neuralwatt API.
+description: Update public or early-access model metadata for the pi-neuralwatt extension. Use when adding or refreshing entries in extensions/provider/models/public-models.ts or extensions/provider/models/early-access.ts, checking Neuralwatt model availability, or syncing hardcoded models with the live Neuralwatt API.
 ---
 
 # Update Neuralwatt models
@@ -12,7 +12,7 @@ shared pricing, modalities, and `thinkingLevelMap`; each variant (`-fast`,
 `-flex`, `-short`, ...) only declares `id`, `name`, `contextWindow`,
 `maxOutputTokens`, `reasoning`, and any override. `buildNeuralwattModel` in
 `extensions/provider/models/build.ts` turns those into `ProviderModelConfig`
-values and is shared with hidden model discovery, so the compat defaults and the
+values and is shared with early-access model discovery, so the compat defaults and the
 `maxTokens` rule live in exactly one place. Add variants to the existing family
 rather than copying a full model literal.
 
@@ -199,11 +199,11 @@ Omitting `max` (or any extended level) marks it unsupported. Only set `max` to a
 - Do not add `compat` fields beyond current repo conventions unless live behavior requires it.
 - Do not ask the user which models to update unless there is a true ambiguity you cannot resolve.
 
-## Adding hidden models
+## Adding early-access models
 
 Use this workflow when a model is available only to authenticated accounts or direct inference requests.
 
-### Choose the hidden model path
+### Choose the early-access model path
 
 First compare these two requests using the same credential:
 
@@ -212,12 +212,12 @@ First compare these two requests using the same credential:
 
 Handle the result as follows:
 
-- If the authenticated catalog includes the model, dynamic discovery in `extensions/provider/models/hidden.ts` should load it. Add an override only when Pi-specific behavior is missing or incorrect.
-- If chat completions accepts the model but the authenticated catalog omits it, add a fully specified entry to `HIDDEN_NEURALWATT_MODELS` in `extensions/provider/models/hidden.ts`.
+- If the authenticated catalog includes the model, dynamic discovery in `extensions/provider/models/early-access.ts` should load it. Add an override only when Pi-specific behavior is missing or incorrect.
+- If chat completions accepts the model but the authenticated catalog omits it, add a fully specified entry to `EARLY_ACCESS_NEURALWATT_MODELS` in `extensions/provider/models/early-access.ts`.
 - If chat completions rejects the model, do not add it. Test likely aliases before concluding that it is unavailable.
-- Never place an API-omitted model in `NEURALWATT_MODELS`. Public definitions are validated against the public catalog and are exposed regardless of `provider.includeHiddenModels`.
+- Never place an API-omitted model in `NEURALWATT_MODELS`. Public definitions are validated against the public catalog and are exposed regardless of `provider.includeEarlyAccessModels`.
 
-`refreshNeuralwattModels` merges hardcoded hidden models with cached and dynamically discovered models for online and offline startup. Public and legacy baseline definitions take precedence over early-access entries. Keep hardcoded early-access IDs unique, and remove or graduate an entry when Neuralwatt starts advertising it publicly.
+`refreshNeuralwattModels` merges hardcoded early-access models with cached and dynamically discovered models for online and offline startup. Public and legacy baseline definitions take precedence over early-access entries. Keep hardcoded early-access IDs unique, and remove or graduate an entry when Neuralwatt starts advertising it publicly.
 
 ### Probe runtime behavior
 
@@ -272,15 +272,15 @@ Document uncertainty in the implementation comment when pricing remains inferred
 
 Read and update:
 
-- `extensions/provider/models/hidden.ts`
+- `extensions/provider/models/early-access.ts`
 - `extensions/provider/models/refresh.ts`
 - `extensions/provider/models/refresh.test.ts`
-- `extensions/provider/models/index.ts` when a new hidden model collection must be exported
+- `extensions/provider/models/index.ts` when a new early-access model collection must be exported
 
 Add tests that prove:
 
-1. The hardcoded hidden model appears and is persisted when `includeHiddenModels` is enabled, even when discovery returns an empty list.
-2. The model is absent when `includeHiddenModels` is disabled.
+1. The hardcoded early-access model appears and is persisted when `includeEarlyAccessModels` is enabled, even when discovery returns an empty list.
+2. The model is absent when `includeEarlyAccessModels` is disabled.
 3. The exact runtime-critical config is preserved: modalities, reasoning mapping, compat fields, context, output limit, and costs.
 4. Public models retain precedence on ID collisions.
 
@@ -292,7 +292,7 @@ pnpm lint
 pnpm test
 ```
 
-Create a patch changeset for the package and stage only the hidden model implementation, tests, and changeset.
+Create a patch changeset for the package and stage only the early-access model implementation, tests, and changeset.
 
 ## Required runtime checks
 
@@ -386,7 +386,7 @@ When done, summarize:
 Use these exact paths in this repo:
 
 - `extensions/provider/models/public-models.ts`
-- `extensions/provider/models/hidden.ts`
+- `extensions/provider/models/early-access.ts`
 - `extensions/provider/models/refresh.ts`
 - `extensions/provider/models/refresh.test.ts`
 - `extensions/provider/models.test.ts`

--- a/.agents/skills/neuralwatt-models/SKILL.md
+++ b/.agents/skills/neuralwatt-models/SKILL.md
@@ -125,6 +125,13 @@ From `metadata`:
 - `deprecated` -> skip model if true
 - `pricing_tbd` -> skip model if true
 
+Flex variants (`-flex`) are the same model, context window, and output cap as the
+standard variant, admitted on spare capacity. They are billed at a 0.65 multiplier
+(35% off) when the request streams, so declare them with
+`costMultiplier: FLEX_COST_MULTIPLIER` rather than copying prices. A non-streaming
+request to a `-flex` model silently falls back to standard tier and standard price.
+See https://portal.neuralwatt.com/docs/guides/flex-tier.
+
 Use portal data or existing conventions for:
 - `fast` (derived from `owned_by === "neuralwatt"` or `-fast` suffix)
 - comments above each model

--- a/.changeset/flex-tier-pricing.md
+++ b/.changeset/flex-tier-pricing.md
@@ -1,0 +1,11 @@
+---
+"@aliou/pi-neuralwatt": patch
+---
+
+Price `-flex` models at the Flex tier discount.
+
+Flex variants were priced like their standard counterparts. They are billed at
+65% of standard (35% off), so cost estimates were overstated by more than a
+third. Note that the discount only applies to streaming requests: a
+non-streaming request to a `-flex` model falls back to the standard tier and the
+standard price.

--- a/.changeset/neuralwatt-model-limits.md
+++ b/.changeset/neuralwatt-model-limits.md
@@ -7,9 +7,12 @@ Correct model output limits and restructure the model catalog.
 `maxTokens` now mirrors the API rule `metadata.limits.max_output_tokens ?? max_model_len`
 instead of defaulting to 65536. This raises the output cap on `glm-5.2`,
 `glm-5.2-fast`, `glm-5.2-flex`, `kimi-k2.6{,-fast,-flex}`, `kimi-k2.7-code{,-flex}`,
-`qwen3.5-397b{,-fast}`, `qwen3.6-35b{,-fast}`, and hidden `kimi-k3`; it lowers
+`qwen3.5-397b{,-fast}`, `qwen3.6-35b{,-fast}`, and early-access `kimi-k3`; it lowers
 `glm-5.2-short-flex` and `glm-5.2-short-fast-flex` to their real 32000 cap.
 
+Flex variants now cost 65% of their standard counterpart, matching the documented
+35% Flex tier discount.
+
 Adds `kimi-k2.7-code-fast`. Public models are now declared as a family/variant
-table built by a shared builder that hidden model discovery reuses, and the drift
+table built by a shared builder that early-access model discovery reuses, and the drift
 test enforces the `maxTokens` rule and skips when the API is unreachable.

--- a/.changeset/neuralwatt-model-limits.md
+++ b/.changeset/neuralwatt-model-limits.md
@@ -1,0 +1,15 @@
+---
+"@aliou/pi-neuralwatt": patch
+---
+
+Correct model output limits and restructure the model catalog.
+
+`maxTokens` now mirrors the API rule `metadata.limits.max_output_tokens ?? max_model_len`
+instead of defaulting to 65536. This raises the output cap on `glm-5.2`,
+`glm-5.2-fast`, `glm-5.2-flex`, `kimi-k2.6{,-fast,-flex}`, `kimi-k2.7-code{,-flex}`,
+`qwen3.5-397b{,-fast}`, `qwen3.6-35b{,-fast}`, and hidden `kimi-k3`; it lowers
+`glm-5.2-short-flex` and `glm-5.2-short-fast-flex` to their real 32000 cap.
+
+Adds `kimi-k2.7-code-fast`. Public models are now declared as a family/variant
+table built by a shared builder that hidden model discovery reuses, and the drift
+test enforces the `maxTokens` rule and skips when the API is unreachable.

--- a/.changeset/rename-hidden-models-to-early-access.md
+++ b/.changeset/rename-hidden-models-to-early-access.md
@@ -1,0 +1,11 @@
+---
+"@aliou/pi-neuralwatt": patch
+---
+
+Rename "hidden models" to "early access models".
+
+These models are not hidden, they are pre-release: Neuralwatt ships them to
+authorized accounts first and most go public later.
+
+`provider.includeHiddenModels` is now `provider.includeEarlyAccessModels`.
+Existing configs are rewritten on load.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,9 +27,10 @@ extensions/
     commands/settings/index.ts          # /neuralwatt:settings command
     models/
       index.ts                          # Re-exports + getNeuralwattModels helper
-      public-models.ts                  # Hardcoded public model definitions
+      build.ts                          # Shared model builder (compat defaults, maxTokens rule)
+      public-models.ts                  # Public model family/variant table
       legacy.ts                         # Phased-out model ID aliases
-      hidden.ts                         # Hidden-model discovery from authenticated /v1/models
+      early-access.ts                   # Early-access model discovery from authenticated /v1/models
       refresh.ts                        # Pi-managed dynamic catalog refresh and cache
   command-quotas/
     index.ts                            # Extension entry (checks config, registers command)
@@ -114,7 +115,7 @@ Usage totals (monthly/lifetime cost in USD) are deliberately not used as a thres
 - **Quota warnings** (`quotaWarnings.enabled`) - Enable/disable low quota notifications
 - **Sub-bar integration** (`subBarIntegration.enabled`) - Show/hide usage in status bar
 - **Legacy model IDs** (`provider.includeLegacyModelIds`) - Include deprecated model aliases
-- **Hidden models** (`provider.includeHiddenModels`) - Include authenticated hidden models
+- **Hidden models** (`provider.includeHiddenModels`) - Include hidden models
 
 The provider itself cannot be disabled. Settings can also be changed via `pi config`. Existing flat config files are migrated to the nested shape automatically.
 
@@ -122,9 +123,19 @@ The provider itself cannot be disabled. Settings can also be changed via `pi con
 
 The provider registers on startup with `NEURALWATT_MODELS` (hardcoded definitions) so models are available without network. Models must be updated manually in `extensions/provider/models/public-models.ts` when the Neuralwatt API adds or changes models.
 
+Public models are declared as a family/variant table. A family holds the defaults its variants share (pricing, modalities, `thinkingLevelMap`); each variant declares its id, name, context window, `maxOutputTokens`, and `reasoning`, plus any override.
+
+Variants combine independent modifiers, not a fixed list: `-short` (smaller context, bounded output), `-fast` (reasoning disabled), and `-flex` (Flex tier). GLM-5.2 alone ships `glm-5.2`, `-fast`, `-flex`, `-short`, `-short-fast`, `-short-flex`, and `-short-fast-flex`. A variant may differ from its family in more than limits: override `cost` when it is priced differently.
+
+`buildNeuralwattModel` in `build.ts` applies the compat defaults and the limit rule `maxTokens = metadata.limits.max_output_tokens ?? max_model_len`; hidden model discovery uses the same builder. `extensions/provider/models.test.ts` diffs the definitions against the live catalog and skips when the API is unreachable.
+
 ### Hidden models
 
-Some Neuralwatt models are accessible via the authenticated API key but not part of the public list. Enabling the `provider.includeHiddenModels` setting makes them available.
+Some Neuralwatt models are pre-release: reachable with an authenticated API key but not yet part of the public `/v1/models` list. They are not secret, and most go public eventually. Enabling the `provider.includeHiddenModels` setting makes them available.
+
+The setting was called `provider.includeHiddenModels` before 0.11. Migration `03-rename-hidden-to-early-access` rewrites it on load.
+
+The config loader reads the file, runs migrations, and hands the rest of the code the current `NeuralwattConfig` shape only. Each migration declares the superseded shape it needs inside its own file. Do not widen loader, settings, or extension types to accept old shapes.
 
 The provider implements Pi's `refreshModels(context)` API. Pi supplies the resolved credential, abort signal, network policy, and provider-scoped model store. Opening `/model` refreshes the catalog in the background; `pi update --models` forces a refresh.
 
@@ -141,5 +152,5 @@ Pi stores the catalog in `${getAgentDir()}/models-store.json`. Public and legacy
 
 1. Check the Neuralwatt API (`https://api.neuralwatt.com/v1/models`) for current model list
 2. Compare against hardcoded definitions in `extensions/provider/models/public-models.ts`
-3. Add missing models, update changed fields (context windows, pricing, capabilities)
+3. Add missing models to the matching family, update changed fields (context windows, pricing, capabilities)
 4. Run `pnpm test` to validate

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,7 +115,7 @@ Usage totals (monthly/lifetime cost in USD) are deliberately not used as a thres
 - **Quota warnings** (`quotaWarnings.enabled`) - Enable/disable low quota notifications
 - **Sub-bar integration** (`subBarIntegration.enabled`) - Show/hide usage in status bar
 - **Legacy model IDs** (`provider.includeLegacyModelIds`) - Include deprecated model aliases
-- **Hidden models** (`provider.includeHiddenModels`) - Include hidden models
+- **Early access models** (`provider.includeEarlyAccessModels`) - Include early-access models
 
 The provider itself cannot be disabled. Settings can also be changed via `pi config`. Existing flat config files are migrated to the nested shape automatically.
 
@@ -127,15 +127,15 @@ Public models are declared as a family/variant table. A family holds the default
 
 Variants combine independent modifiers, not a fixed list: `-short` (smaller context, bounded output), `-fast` (reasoning disabled), and `-flex` (Flex tier). GLM-5.2 alone ships `glm-5.2`, `-fast`, `-flex`, `-short`, `-short-fast`, `-short-flex`, and `-short-fast-flex`. A variant may differ from its family in more than limits: override `cost` for a variant priced differently, or set `costMultiplier` for a proportional change such as the Flex discount.
 
-`buildNeuralwattModel` in `build.ts` applies the compat defaults and the limit rule `maxTokens = metadata.limits.max_output_tokens ?? max_model_len`; hidden model discovery uses the same builder. `extensions/provider/models.test.ts` diffs the definitions against the live catalog and skips when the API is unreachable.
+`buildNeuralwattModel` in `build.ts` applies the compat defaults and the limit rule `maxTokens = metadata.limits.max_output_tokens ?? max_model_len`; early-access model discovery uses the same builder. `extensions/provider/models.test.ts` diffs the definitions against the live catalog and skips when the API is unreachable.
 
 ### Flex variants
 
 `-flex` models are the [Flex tier](https://portal.neuralwatt.com/docs/guides/flex-tier): same model, limits, and prompt cache as the standard variant, but admitted when there is spare capacity. They are billed at 65% of standard (35% off), applied through `costMultiplier` on the variant. The discount only applies to streaming requests; a non-streaming request to a `-flex` model falls back to the standard tier and standard price, and reports `service_tier: "standard"`. Flex models are not in the public `/v1/models` response, so the drift test skips them.
 
-### Hidden models
+### Early access models
 
-Some Neuralwatt models are pre-release: reachable with an authenticated API key but not yet part of the public `/v1/models` list. They are not secret, and most go public eventually. Enabling the `provider.includeHiddenModels` setting makes them available.
+Some Neuralwatt models are pre-release: reachable with an authenticated API key but not yet part of the public `/v1/models` list. They are not secret, and most go public eventually. Enabling the `provider.includeEarlyAccessModels` setting makes them available.
 
 The setting was called `provider.includeHiddenModels` before 0.11. Migration `03-rename-hidden-to-early-access` rewrites it on load.
 
@@ -146,9 +146,9 @@ The provider implements Pi's `refreshModels(context)` API. Pi supplies the resol
 The refresh flow is:
 
 1. Register hardcoded public models and configured legacy aliases synchronously.
-2. During offline startup, restore dynamic hidden models from Pi's provider-scoped cache.
-3. During network refresh, fetch authenticated `/v1/models`, combine hidden models with current public and legacy definitions, and persist the complete effective catalog through `context.store`.
-4. Preserve the stale catalog when a network refresh fails. A successful empty result purges removed hidden models.
+2. During offline startup, restore dynamic early-access models from Pi's provider-scoped cache.
+3. During network refresh, fetch authenticated `/v1/models`, combine early-access models with current public and legacy definitions, and persist the complete effective catalog through `context.store`.
+4. Preserve the stale catalog when a network refresh fails. A successful empty result purges removed early-access models.
 
 Pi stores the catalog in `${getAgentDir()}/models-store.json`. Public and legacy definitions in source remain authoritative over cached copies.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,9 +125,13 @@ The provider registers on startup with `NEURALWATT_MODELS` (hardcoded definition
 
 Public models are declared as a family/variant table. A family holds the defaults its variants share (pricing, modalities, `thinkingLevelMap`); each variant declares its id, name, context window, `maxOutputTokens`, and `reasoning`, plus any override.
 
-Variants combine independent modifiers, not a fixed list: `-short` (smaller context, bounded output), `-fast` (reasoning disabled), and `-flex` (Flex tier). GLM-5.2 alone ships `glm-5.2`, `-fast`, `-flex`, `-short`, `-short-fast`, `-short-flex`, and `-short-fast-flex`. A variant may differ from its family in more than limits: override `cost` when it is priced differently.
+Variants combine independent modifiers, not a fixed list: `-short` (smaller context, bounded output), `-fast` (reasoning disabled), and `-flex` (Flex tier). GLM-5.2 alone ships `glm-5.2`, `-fast`, `-flex`, `-short`, `-short-fast`, `-short-flex`, and `-short-fast-flex`. A variant may differ from its family in more than limits: override `cost` for a variant priced differently, or set `costMultiplier` for a proportional change such as the Flex discount.
 
 `buildNeuralwattModel` in `build.ts` applies the compat defaults and the limit rule `maxTokens = metadata.limits.max_output_tokens ?? max_model_len`; hidden model discovery uses the same builder. `extensions/provider/models.test.ts` diffs the definitions against the live catalog and skips when the API is unreachable.
+
+### Flex variants
+
+`-flex` models are the [Flex tier](https://portal.neuralwatt.com/docs/guides/flex-tier): same model, limits, and prompt cache as the standard variant, but admitted when there is spare capacity. They are billed at 65% of standard (35% off), applied through `costMultiplier` on the variant. The discount only applies to streaming requests; a non-streaming request to a `-flex` model falls back to the standard tier and standard price, and reports `service_tier: "standard"`. Flex models are not in the public `/v1/models` response, so the drift test skips them.
 
 ### Hidden models
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Configure features with `/neuralwatt:settings`:
 - **Quota warnings** — Enable/disable low quota notifications
 - **Sub-bar integration** — Show/hide usage in status bar
 - **Legacy model IDs** — Include deprecated model aliases
-- **Hidden models** — Include models available only to the configured API key
+- **Early access models** — Include pre-release models available only to the configured API key
 
 The provider itself cannot be disabled — it is always loaded.
 
@@ -86,7 +86,7 @@ Configuration uses nested per-feature sections. Existing flat config files are m
 
 ### Model Refresh
 
-Neuralwatt registers its public models without network access. When hidden models are enabled, opening `/model` refreshes the authenticated catalog in the background. `pi update --models` forces an immediate refresh.
+Neuralwatt registers its public models without network access. When early-access models are enabled, opening `/model` refreshes the authenticated catalog in the background. `pi update --models` forces an immediate refresh.
 
 Pi stores the complete effective Neuralwatt catalog in `~/.pi/agent/models-store.json` for offline startup. Current hardcoded public and legacy definitions remain authoritative when cached models are restored.
 

--- a/extensions/provider/commands/settings/index.ts
+++ b/extensions/provider/commands/settings/index.ts
@@ -7,7 +7,6 @@ import type { SettingItem } from "@earendil-works/pi-tui";
 import {
   configLoader,
   type NeuralwattConfig,
-  type NeuralwattRawConfig,
   type ResolvedNeuralwattConfig,
 } from "../../../../src/config";
 import {
@@ -50,51 +49,11 @@ function featureRow(
   };
 }
 
-function optionalFeatureValue(value: unknown): boolean | undefined {
-  if (typeof value === "boolean") return value;
-  if (value && typeof value === "object") {
-    const enabled = (value as { enabled?: boolean }).enabled;
-    if (typeof enabled === "boolean") return enabled;
-  }
-  return undefined;
-}
-
-function featureValue(value: unknown, fallback: boolean): boolean {
-  return optionalFeatureValue(value) ?? fallback;
-}
-
-function toNestedConfig(config: NeuralwattRawConfig): NeuralwattConfig {
-  const provider = "provider" in config ? config.provider : undefined;
-
-  return {
-    provider: {
-      ...(provider ?? {}),
-      includeLegacyModelIds:
-        provider?.includeLegacyModelIds ??
-        ("includeLegacyModelIds" in config
-          ? config.includeLegacyModelIds
-          : undefined),
-      includeHiddenModels:
-        provider?.includeHiddenModels ??
-        ("includeHiddenModels" in config
-          ? config.includeHiddenModels
-          : undefined),
-    },
-    quotaCommand: {
-      ...(typeof config.quotaCommand === "object" ? config.quotaCommand : {}),
-      enabled: optionalFeatureValue(config.quotaCommand),
-    },
-    quotaWarnings: {
-      ...(typeof config.quotaWarnings === "object" ? config.quotaWarnings : {}),
-      enabled: optionalFeatureValue(config.quotaWarnings),
-    },
-    subBarIntegration: {
-      ...(typeof config.subBarIntegration === "object"
-        ? config.subBarIntegration
-        : {}),
-      enabled: optionalFeatureValue(config.subBarIntegration),
-    },
-  };
+function featureValue(
+  section: { enabled?: boolean } | undefined,
+  fallback: boolean,
+): boolean {
+  return section?.enabled ?? fallback;
 }
 
 export function registerNeuralwattSettings(
@@ -103,7 +62,7 @@ export function registerNeuralwattSettings(
 ): void {
   const { getLoadedFeatures } = options;
 
-  registerSettingsCommand<NeuralwattRawConfig, ResolvedNeuralwattConfig>(pi, {
+  registerSettingsCommand<NeuralwattConfig, ResolvedNeuralwattConfig>(pi, {
     commandName: "neuralwatt:settings",
     title: "Neuralwatt Settings",
     configStore: configLoader,
@@ -154,30 +113,20 @@ export function registerNeuralwattSettings(
               description:
                 "Include deprecated Neuralwatt model IDs as aliases in the model picker",
               currentValue:
-                ((tabConfig &&
-                  "provider" in tabConfig &&
-                  tabConfig.provider?.includeLegacyModelIds) ??
-                (tabConfig &&
-                  "includeLegacyModelIds" in tabConfig &&
-                  tabConfig.includeLegacyModelIds) ??
+                (tabConfig?.provider?.includeLegacyModelIds ??
                 resolved.provider.includeLegacyModelIds)
                   ? "include"
                   : "ignore",
               values: ["include", "ignore"],
             },
             {
-              id: "includeHiddenModels",
-              label: "Hidden models",
+              id: "includeEarlyAccessModels",
+              label: "Early access models",
               description:
-                "Include Neuralwatt models that are accessible via API key but not advertised in the public model list",
+                "Include pre-release Neuralwatt models that your API key can reach but that are not yet in the public model list",
               currentValue:
-                ((tabConfig &&
-                  "provider" in tabConfig &&
-                  tabConfig.provider?.includeHiddenModels) ??
-                (tabConfig &&
-                  "includeHiddenModels" in tabConfig &&
-                  tabConfig.includeHiddenModels) ??
-                resolved.provider.includeHiddenModels)
+                (tabConfig?.provider?.includeEarlyAccessModels ??
+                resolved.provider.includeEarlyAccessModels)
                   ? "include"
                   : "ignore",
               values: ["include", "ignore"],
@@ -190,23 +139,21 @@ export function registerNeuralwattSettings(
       // Non-feature toggles are handled first so they are not blocked by the
       // loaded-features guard (they are managed directly by the provider).
       if (id === "includeLegacyModelIds") {
-        const nestedConfig = toNestedConfig(config);
         return {
-          ...nestedConfig,
+          ...config,
           provider: {
-            ...nestedConfig.provider,
+            ...config.provider,
             includeLegacyModelIds: newValue === "include",
           },
         };
       }
 
-      if (id === "includeHiddenModels") {
-        const nestedConfig = toNestedConfig(config);
+      if (id === "includeEarlyAccessModels") {
         return {
-          ...nestedConfig,
+          ...config,
           provider: {
-            ...nestedConfig.provider,
-            includeHiddenModels: newValue === "include",
+            ...config.provider,
+            includeEarlyAccessModels: newValue === "include",
           },
         };
       }
@@ -219,21 +166,18 @@ export function registerNeuralwattSettings(
       switch (id) {
         case "quotaCommand":
           return {
-            ...toNestedConfig(config),
-            quotaCommand: { ...toNestedConfig(config).quotaCommand, enabled },
+            ...config,
+            quotaCommand: { ...config.quotaCommand, enabled },
           };
         case "quotaWarnings":
           return {
-            ...toNestedConfig(config),
-            quotaWarnings: { ...toNestedConfig(config).quotaWarnings, enabled },
+            ...config,
+            quotaWarnings: { ...config.quotaWarnings, enabled },
           };
         case "subBarIntegration":
           return {
-            ...toNestedConfig(config),
-            subBarIntegration: {
-              ...toNestedConfig(config).subBarIntegration,
-              enabled,
-            },
+            ...config,
+            subBarIntegration: { ...config.subBarIntegration, enabled },
           };
         default:
           return null;

--- a/extensions/provider/index.ts
+++ b/extensions/provider/index.ts
@@ -61,8 +61,8 @@ function registerNeuralwattProvider(
       refreshNeuralwattModels(context, {
         includeLegacyModelIds:
           configLoader.getConfig().provider.includeLegacyModelIds,
-        includeHiddenModels:
-          configLoader.getConfig().provider.includeHiddenModels,
+        includeEarlyAccessModels:
+          configLoader.getConfig().provider.includeEarlyAccessModels,
       }),
   };
 
@@ -113,8 +113,8 @@ export default async function (pi: ExtensionAPI) {
     if (
       next.includeLegacyModelIds ===
         registeredProviderSettings.includeLegacyModelIds &&
-      next.includeHiddenModels ===
-        registeredProviderSettings.includeHiddenModels
+      next.includeEarlyAccessModels ===
+        registeredProviderSettings.includeEarlyAccessModels
     ) {
       return;
     }

--- a/extensions/provider/models.test.ts
+++ b/extensions/provider/models.test.ts
@@ -5,6 +5,7 @@ import {
   LEGACY_NEURALWATT_MODEL_IDS,
   NEURALWATT_MODELS,
 } from "./models";
+import { FLEX_COST_MULTIPLIER } from "./models/build";
 
 interface ApiModelMetadata {
   display_name: string;
@@ -342,6 +343,32 @@ describe("Neuralwatt models", () => {
     expect(byId.get("kimi-k2.7-code-flex")?.thinkingLevelMap).toEqual(
       byId.get("kimi-k2.7-code")?.thinkingLevelMap,
     );
+  });
+
+  it("should price flex variants with the flex multiplier", () => {
+    const byId = new Map(NEURALWATT_MODELS.map((m) => [m.id, m]));
+    const pairs: [string, string][] = [
+      ["glm-5.2-flex", "glm-5.2"],
+      ["glm-5.2-short-flex", "glm-5.2-short"],
+      ["glm-5.2-short-fast-flex", "glm-5.2-short-fast"],
+      ["kimi-k2.6-flex", "kimi-k2.6"],
+      ["kimi-k2.7-code-flex", "kimi-k2.7-code"],
+    ];
+
+    for (const [flexId, standardId] of pairs) {
+      const flex = byId.get(flexId);
+      const standard = byId.get(standardId);
+      expect(flex, flexId).toBeDefined();
+      expect(standard, standardId).toBeDefined();
+      if (!flex || !standard) continue;
+
+      for (const field of ["input", "output", "cacheRead"] as const) {
+        expect(flex.cost[field], `${flexId}.cost.${field}`).toBeCloseTo(
+          standard.cost[field] * FLEX_COST_MULTIPLIER,
+          6,
+        );
+      }
+    }
   });
 
   it("should only include legacy model IDs when enabled", () => {

--- a/extensions/provider/models.test.ts
+++ b/extensions/provider/models.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
+  EARLY_ACCESS_NEURALWATT_MODELS,
   getNeuralwattModels,
-  HIDDEN_NEURALWATT_MODELS,
   LEGACY_NEURALWATT_MODEL_IDS,
   NEURALWATT_MODELS,
 } from "./models";
@@ -270,7 +270,10 @@ describe("Neuralwatt models", () => {
   });
 
   it("should never allow more output tokens than context", () => {
-    for (const model of [...NEURALWATT_MODELS, ...HIDDEN_NEURALWATT_MODELS]) {
+    for (const model of [
+      ...NEURALWATT_MODELS,
+      ...EARLY_ACCESS_NEURALWATT_MODELS,
+    ]) {
       expect(model.maxTokens, model.id).toBeGreaterThan(0);
       expect(model.maxTokens, model.id).toBeLessThanOrEqual(
         model.contextWindow,
@@ -278,9 +281,9 @@ describe("Neuralwatt models", () => {
     }
   });
 
-  it("should keep hidden model IDs out of the public catalog", () => {
+  it("should keep early-access model IDs out of the public catalog", () => {
     const publicIds = new Set(NEURALWATT_MODELS.map((m) => m.id));
-    for (const model of HIDDEN_NEURALWATT_MODELS) {
+    for (const model of EARLY_ACCESS_NEURALWATT_MODELS) {
       expect(publicIds.has(model.id), model.id).toBe(false);
     }
   });

--- a/extensions/provider/models.test.ts
+++ b/extensions/provider/models.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   getNeuralwattModels,
+  HIDDEN_NEURALWATT_MODELS,
   LEGACY_NEURALWATT_MODEL_IDS,
   NEURALWATT_MODELS,
 } from "./models";
@@ -64,13 +65,23 @@ function isFlexModelId(id: string): boolean {
   return id.endsWith("-flex");
 }
 
-async function fetchApiModels(): Promise<ApiModel[]> {
-  const response = await fetch("https://api.neuralwatt.com/v1/models", {
-    headers: {
-      Referer: "https://github.com/aliou/pi-neuralwatt",
-      "X-Title": "npm:@aliou/pi-neuralwatt",
-    },
-  });
+/**
+ * Returns undefined only when the network is unavailable, so offline runs skip.
+ * An HTTP error is a real contract failure and still fails the test.
+ */
+async function fetchApiModels(): Promise<ApiModel[] | undefined> {
+  let response: Response;
+  try {
+    response = await fetch("https://api.neuralwatt.com/v1/models", {
+      signal: AbortSignal.timeout(15_000),
+      headers: {
+        Referer: "https://github.com/aliou/pi-neuralwatt",
+        "X-Title": "npm:@aliou/pi-neuralwatt",
+      },
+    });
+  } catch {
+    return undefined;
+  }
 
   if (!response.ok) {
     throw new Error(
@@ -191,17 +202,17 @@ function compareModels(
       }
     }
 
-    // Check maxTokens when API provides it
-    if (
-      meta?.limits.max_output_tokens !== null &&
-      meta?.limits.max_output_tokens !== undefined
-    ) {
-      if (meta.limits.max_output_tokens !== hardcoded.maxTokens) {
+    // Check maxTokens. A null `max_output_tokens` means the API imposes no
+    // separate output cap, so output is bounded by the context window.
+    if (meta) {
+      const expectedMaxTokens =
+        meta.limits.max_output_tokens ?? apiModel.max_model_len;
+      if (expectedMaxTokens !== hardcoded.maxTokens) {
         discrepancies.push({
           model: hardcoded.id,
           field: "maxTokens",
           hardcoded: hardcoded.maxTokens,
-          api: meta.limits.max_output_tokens,
+          api: expectedMaxTokens,
         });
       }
     }
@@ -224,8 +235,15 @@ function compareModels(
 }
 
 describe("Neuralwatt models", () => {
-  it("should match API model definitions", { timeout: 30000 }, async () => {
+  it("should match API model definitions", {
+    timeout: 30000,
+  }, async (context) => {
     const apiModels = await fetchApiModels();
+    if (!apiModels) {
+      context.skip("Neuralwatt model catalog unreachable");
+      return;
+    }
+
     const discrepancies = compareModels(apiModels, NEURALWATT_MODELS);
 
     if (discrepancies.length > 0) {
@@ -248,6 +266,22 @@ describe("Neuralwatt models", () => {
     }
 
     expect(discrepancies).toHaveLength(0);
+  });
+
+  it("should never allow more output tokens than context", () => {
+    for (const model of [...NEURALWATT_MODELS, ...HIDDEN_NEURALWATT_MODELS]) {
+      expect(model.maxTokens, model.id).toBeGreaterThan(0);
+      expect(model.maxTokens, model.id).toBeLessThanOrEqual(
+        model.contextWindow,
+      );
+    }
+  });
+
+  it("should keep hidden model IDs out of the public catalog", () => {
+    const publicIds = new Set(NEURALWATT_MODELS.map((m) => m.id));
+    for (const model of HIDDEN_NEURALWATT_MODELS) {
+      expect(publicIds.has(model.id), model.id).toBe(false);
+    }
   });
 
   it("should have unique model IDs", () => {

--- a/extensions/provider/models/build.ts
+++ b/extensions/provider/models/build.ts
@@ -1,0 +1,101 @@
+import type { ProviderModelConfig } from "@earendil-works/pi-coding-agent";
+
+export type ThinkingLevelMap = NonNullable<
+  ProviderModelConfig["thinkingLevelMap"]
+>;
+
+export interface NeuralwattCost {
+  input: number;
+  output: number;
+  cacheRead: number;
+}
+
+/**
+ * Shared metadata for every variant of a Neuralwatt model (base, `-fast`,
+ * `-flex`, `-short`, ...). Variants only declare what differs.
+ */
+export interface NeuralwattModelFamily {
+  cost: NeuralwattCost;
+  vision: boolean;
+  /** Thinking levels used by reasoning variants of this family. */
+  thinkingLevelMap?: ThinkingLevelMap;
+}
+
+export interface NeuralwattVariantSpec {
+  id: string;
+  name: string;
+  /** `max_model_len` from /v1/models. */
+  contextWindow: number;
+  /**
+   * `metadata.limits.max_output_tokens` from /v1/models. `null` means the API
+   * imposes no separate output cap, so output is bounded by the context window.
+   */
+  maxOutputTokens: number | null;
+  reasoning: boolean;
+  cost?: Partial<NeuralwattCost>;
+  vision?: boolean;
+  thinkingLevelMap?: ThinkingLevelMap;
+}
+
+/**
+ * Neuralwatt reports `max_output_tokens: null` for models whose output is only
+ * bounded by the context window. Mirror the API instead of inventing a cap.
+ */
+export function resolveMaxTokens(
+  maxOutputTokens: number | null | undefined,
+  contextWindow: number,
+): number {
+  return maxOutputTokens ?? contextWindow;
+}
+
+export function buildNeuralwattModel(
+  family: NeuralwattModelFamily,
+  variant: NeuralwattVariantSpec,
+): ProviderModelConfig {
+  const vision = variant.vision ?? family.vision;
+
+  const compat: NonNullable<ProviderModelConfig["compat"]> = {
+    supportsDeveloperRole: false,
+    maxTokensField: "max_tokens",
+  };
+  if (variant.reasoning) {
+    compat.requiresReasoningContentOnAssistantMessages = true;
+  }
+
+  const model: ProviderModelConfig = {
+    id: variant.id,
+    name: variant.name,
+    reasoning: variant.reasoning,
+    input: vision ? ["text", "image"] : ["text"],
+    cost: {
+      input: variant.cost?.input ?? family.cost.input,
+      output: variant.cost?.output ?? family.cost.output,
+      cacheRead: variant.cost?.cacheRead ?? family.cost.cacheRead,
+      cacheWrite: 0,
+    },
+    contextWindow: variant.contextWindow,
+    maxTokens: resolveMaxTokens(variant.maxOutputTokens, variant.contextWindow),
+    compat,
+  };
+
+  if (variant.reasoning) {
+    const thinkingLevelMap =
+      variant.thinkingLevelMap ?? family.thinkingLevelMap;
+    if (!thinkingLevelMap) {
+      throw new Error(
+        `Missing thinkingLevelMap for reasoning model ${variant.id}`,
+      );
+    }
+    // Clone so variants never share a family map instance.
+    model.thinkingLevelMap = { ...thinkingLevelMap };
+  }
+
+  return model;
+}
+
+export function buildNeuralwattFamily(
+  family: NeuralwattModelFamily,
+  variants: NeuralwattVariantSpec[],
+): ProviderModelConfig[] {
+  return variants.map((variant) => buildNeuralwattModel(family, variant));
+}

--- a/extensions/provider/models/build.ts
+++ b/extensions/provider/models/build.ts
@@ -4,6 +4,15 @@ export type ThinkingLevelMap = NonNullable<
   ProviderModelConfig["thinkingLevelMap"]
 >;
 
+/**
+ * Flex tier is billed at 65% of standard pricing (35% off) when the request
+ * streams. A non-streaming request to a `-flex` model silently falls back to
+ * the standard tier and the standard price.
+ *
+ * https://portal.neuralwatt.com/docs/guides/flex-tier
+ */
+export const FLEX_COST_MULTIPLIER = 0.65;
+
 export interface NeuralwattCost {
   input: number;
   output: number;
@@ -33,6 +42,11 @@ export interface NeuralwattVariantSpec {
   maxOutputTokens: number | null;
   reasoning: boolean;
   cost?: Partial<NeuralwattCost>;
+  /**
+   * Multiplier applied to the family cost, e.g. the Flex tier discount.
+   * Applied after any per-variant `cost` override.
+   */
+  costMultiplier?: number;
   vision?: boolean;
   thinkingLevelMap?: ThinkingLevelMap;
 }
@@ -62,15 +76,19 @@ export function buildNeuralwattModel(
     compat.requiresReasoningContentOnAssistantMessages = true;
   }
 
+  const multiplier = variant.costMultiplier ?? 1;
+  const scale = (value: number): number =>
+    multiplier === 1 ? value : Number((value * multiplier).toFixed(6));
+
   const model: ProviderModelConfig = {
     id: variant.id,
     name: variant.name,
     reasoning: variant.reasoning,
     input: vision ? ["text", "image"] : ["text"],
     cost: {
-      input: variant.cost?.input ?? family.cost.input,
-      output: variant.cost?.output ?? family.cost.output,
-      cacheRead: variant.cost?.cacheRead ?? family.cost.cacheRead,
+      input: scale(variant.cost?.input ?? family.cost.input),
+      output: scale(variant.cost?.output ?? family.cost.output),
+      cacheRead: scale(variant.cost?.cacheRead ?? family.cost.cacheRead),
       cacheWrite: 0,
     },
     contextWindow: variant.contextWindow,

--- a/extensions/provider/models/early-access.ts
+++ b/extensions/provider/models/early-access.ts
@@ -4,11 +4,12 @@ import type { NeuralwattApiModel } from "../../../src/types/models-api";
 import { buildNeuralwattModel, resolveMaxTokens } from "./build";
 import { NEURALWATT_MODELS } from "./public-models";
 
-// Hidden models available to authorized accounts but omitted from the public
-// /v1/models response. Keep these gated by includeHiddenModels and hardcode
-// early-access entries so they remain available from the offline catalog.
+// Pre-release models. Neuralwatt ships these to authorized accounts before they
+// reach the public /v1/models response; most go public eventually. Keep them
+// gated by includeEarlyAccessModels and hardcode entries so they remain
+// available from the offline catalog.
 // Move an entry to public-models.ts once Neuralwatt advertises it publicly.
-export const HIDDEN_NEURALWATT_MODELS: ProviderModelConfig[] = [
+export const EARLY_ACCESS_NEURALWATT_MODELS: ProviderModelConfig[] = [
   // Kimi K3 - early-access MoonshotAI multimodal MoE.
   // Metadata is sourced from Neuralwatt's authenticated model catalog.
   buildNeuralwattModel(
@@ -33,18 +34,20 @@ export const HIDDEN_NEURALWATT_MODELS: ProviderModelConfig[] = [
   ),
 ];
 
-// Per-ID overrides for known hidden models. The authenticated /v1/models endpoint
-// exposes pricing and capabilities, but some Pi-specific behavior
+// Per-ID overrides for known early-access models. The authenticated /v1/models
+// endpoint exposes pricing and capabilities, but some Pi-specific behavior
 // (thinking levels, compat flags) has to be supplied by hand.
-// Previously hidden models that have since gone public now live in public-models.ts.
-const HIDDEN_MODEL_OVERRIDES: Partial<
+// Models that have since gone public now live in public-models.ts.
+const EARLY_ACCESS_MODEL_OVERRIDES: Partial<
   Record<string, Partial<ProviderModelConfig>>
 > = {};
 
-function buildHiddenModel(apiModel: NeuralwattApiModel): ProviderModelConfig {
+function buildEarlyAccessModel(
+  apiModel: NeuralwattApiModel,
+): ProviderModelConfig {
   const meta = apiModel.metadata;
   const reasoning = meta?.capabilities.reasoning ?? false;
-  const override = HIDDEN_MODEL_OVERRIDES[apiModel.id];
+  const override = EARLY_ACCESS_MODEL_OVERRIDES[apiModel.id];
 
   const compat: NonNullable<ProviderModelConfig["compat"]> = {
     supportsDeveloperRole: false,
@@ -87,13 +90,13 @@ function buildHiddenModel(apiModel: NeuralwattApiModel): ProviderModelConfig {
   }
 
   if (override) {
-    return applyHiddenOverride(model, override);
+    return applyEarlyAccessOverride(model, override);
   }
 
   return model;
 }
 
-function applyHiddenOverride(
+function applyEarlyAccessOverride(
   model: ProviderModelConfig,
   override: Partial<ProviderModelConfig>,
 ): ProviderModelConfig {
@@ -120,14 +123,14 @@ function applyHiddenOverride(
 }
 
 /**
- * Load hidden models from the authenticated /v1/models endpoint.
+ * Load early-access models from the authenticated /v1/models endpoint.
  *
- * Hidden models are any models returned by the API that are not already
+ * Early-access models are any models returned by the API that are not already
  * part of the public hardcoded list. If the API key is missing or the request
  * fails, an `undefined` distinguishes an unavailable/failed request from a
  * successful empty list, allowing refresh callers to preserve stale cache.
  */
-export async function loadHiddenModels(
+export async function loadEarlyAccessModels(
   apiKey: string,
   signal?: AbortSignal,
 ): Promise<ProviderModelConfig[] | undefined> {
@@ -144,5 +147,5 @@ export async function loadHiddenModels(
         !model.metadata?.deprecated && !model.metadata?.pricing.pricing_tbd,
     )
     .filter((model) => !publicIds.has(model.id))
-    .map(buildHiddenModel);
+    .map(buildEarlyAccessModel);
 }

--- a/extensions/provider/models/hidden.ts
+++ b/extensions/provider/models/hidden.ts
@@ -1,6 +1,7 @@
 import type { ProviderModelConfig } from "@earendil-works/pi-coding-agent";
 import { fetchNeuralwattModels } from "../../../src/lib/neuralwatt-api";
 import type { NeuralwattApiModel } from "../../../src/types/models-api";
+import { buildNeuralwattModel, resolveMaxTokens } from "./build";
 import { NEURALWATT_MODELS } from "./public-models";
 
 // Hidden models available to authorized accounts but omitted from the public
@@ -10,37 +11,31 @@ import { NEURALWATT_MODELS } from "./public-models";
 export const HIDDEN_NEURALWATT_MODELS: ProviderModelConfig[] = [
   // Kimi K3 - early-access MoonshotAI multimodal MoE.
   // Metadata is sourced from Neuralwatt's authenticated model catalog.
-  {
-    id: "kimi-k3",
-    name: "Kimi K3",
-    reasoning: true,
-    input: ["text", "image"],
-    cost: {
-      input: 3,
-      output: 15,
-      cacheRead: 0.3,
-      cacheWrite: 0,
+  buildNeuralwattModel(
+    {
+      cost: { input: 3, output: 15, cacheRead: 0.3 },
+      vision: true,
+      thinkingLevelMap: {
+        minimal: null,
+        low: null,
+        medium: "medium",
+        high: null,
+        xhigh: null,
+      },
     },
-    contextWindow: 1048560,
-    maxTokens: 65536,
-    thinkingLevelMap: {
-      minimal: null,
-      low: null,
-      medium: "medium",
-      high: null,
-      xhigh: null,
+    {
+      id: "kimi-k3",
+      name: "Kimi K3",
+      contextWindow: 1048560,
+      maxOutputTokens: null,
+      reasoning: true,
     },
-    compat: {
-      supportsDeveloperRole: false,
-      maxTokensField: "max_tokens",
-      requiresReasoningContentOnAssistantMessages: true,
-    },
-  },
+  ),
 ];
 
 // Per-ID overrides for known hidden models. The authenticated /v1/models endpoint
-// exposes pricing and capabilities, but some Pi-specific behavior (thinking levels,
-// compat flags) has to be supplied by hand.
+// exposes pricing and capabilities, but some Pi-specific behavior
+// (thinking levels, compat flags) has to be supplied by hand.
 // Previously hidden models that have since gone public now live in public-models.ts.
 const HIDDEN_MODEL_OVERRIDES: Partial<
   Record<string, Partial<ProviderModelConfig>>
@@ -74,7 +69,10 @@ function buildHiddenModel(apiModel: NeuralwattApiModel): ProviderModelConfig {
       cacheWrite: meta?.pricing.cached_output_per_million ?? 0,
     },
     contextWindow: apiModel.max_model_len,
-    maxTokens: meta?.limits.max_output_tokens ?? 65536,
+    maxTokens: resolveMaxTokens(
+      meta?.limits.max_output_tokens,
+      apiModel.max_model_len,
+    ),
     compat,
   };
 
@@ -124,10 +122,10 @@ function applyHiddenOverride(
 /**
  * Load hidden models from the authenticated /v1/models endpoint.
  *
- * Hidden models are any models returned by the API that are not already part of
- * the public hardcoded list. If the API key is missing or the request fails, an
- * `undefined` distinguishes an unavailable/failed request from a successful
- * empty hidden-model list, allowing refresh callers to preserve stale cache.
+ * Hidden models are any models returned by the API that are not already
+ * part of the public hardcoded list. If the API key is missing or the request
+ * fails, an `undefined` distinguishes an unavailable/failed request from a
+ * successful empty list, allowing refresh callers to preserve stale cache.
  */
 export async function loadHiddenModels(
   apiKey: string,

--- a/extensions/provider/models/index.ts
+++ b/extensions/provider/models/index.ts
@@ -2,7 +2,10 @@ import type { ProviderModelConfig } from "@earendil-works/pi-coding-agent";
 import { buildLegacyNeuralwattModels } from "./legacy";
 import { NEURALWATT_MODELS } from "./public-models";
 
-export { HIDDEN_NEURALWATT_MODELS, loadHiddenModels } from "./hidden";
+export {
+  EARLY_ACCESS_NEURALWATT_MODELS,
+  loadEarlyAccessModels,
+} from "./early-access";
 export {
   buildLegacyNeuralwattModels,
   LEGACY_MODEL_ALIAS_MAP,

--- a/extensions/provider/models/public-models.ts
+++ b/extensions/provider/models/public-models.ts
@@ -1,6 +1,7 @@
 import type { ProviderModelConfig } from "@earendil-works/pi-coding-agent";
 import {
   buildNeuralwattFamily,
+  FLEX_COST_MULTIPLIER,
   type NeuralwattModelFamily,
   type NeuralwattVariantSpec,
   type ThinkingLevelMap,
@@ -138,6 +139,7 @@ const FAMILIES: [NeuralwattModelFamily, NeuralwattVariantSpec[]][] = [
         contextWindow: 1048560,
         maxOutputTokens: null,
         reasoning: true,
+        costMultiplier: FLEX_COST_MULTIPLIER,
       },
       {
         id: "glm-5.2-short",
@@ -159,6 +161,7 @@ const FAMILIES: [NeuralwattModelFamily, NeuralwattVariantSpec[]][] = [
         contextWindow: 199984,
         maxOutputTokens: 32000,
         reasoning: true,
+        costMultiplier: FLEX_COST_MULTIPLIER,
       },
       {
         id: "glm-5.2-short-fast-flex",
@@ -166,6 +169,7 @@ const FAMILIES: [NeuralwattModelFamily, NeuralwattVariantSpec[]][] = [
         contextWindow: 199984,
         maxOutputTokens: 32000,
         reasoning: false,
+        costMultiplier: FLEX_COST_MULTIPLIER,
       },
     ],
   ],
@@ -192,6 +196,7 @@ const FAMILIES: [NeuralwattModelFamily, NeuralwattVariantSpec[]][] = [
         contextWindow: 262128,
         maxOutputTokens: null,
         reasoning: true,
+        costMultiplier: FLEX_COST_MULTIPLIER,
       },
     ],
   ],
@@ -218,6 +223,7 @@ const FAMILIES: [NeuralwattModelFamily, NeuralwattVariantSpec[]][] = [
         contextWindow: 262128,
         maxOutputTokens: null,
         reasoning: true,
+        costMultiplier: FLEX_COST_MULTIPLIER,
       },
     ],
   ],
@@ -261,8 +267,11 @@ const FAMILIES: [NeuralwattModelFamily, NeuralwattVariantSpec[]][] = [
   ],
 ];
 
-// `-flex` variants are not advertised by the public /v1/models response; the
-// drift check in models.test.ts tolerates them instead of failing on them.
+// `-flex` variants are the Flex tier: same model, context window, output cap,
+// and prompt cache as the standard variant, admitted on spare capacity.
+// /v1/models does not advertise them (not even to an authenticated key), so they
+// stay hardcoded here and the drift check in models.test.ts skips them.
+// https://portal.neuralwatt.com/docs/guides/flex-tier
 
 export const NEURALWATT_MODELS: ProviderModelConfig[] = FAMILIES.flatMap(
   ([family, variants]) => buildNeuralwattFamily(family, variants),

--- a/extensions/provider/models/public-models.ts
+++ b/extensions/provider/models/public-models.ts
@@ -1,451 +1,269 @@
 import type { ProviderModelConfig } from "@earendil-works/pi-coding-agent";
+import {
+  buildNeuralwattFamily,
+  type NeuralwattModelFamily,
+  type NeuralwattVariantSpec,
+  type ThinkingLevelMap,
+} from "./build";
 
-// Public models returned by https://api.neuralwatt.com/v1/models (unauthenticated view).
-// Pricing, capabilities, and limits are sourced from the API metadata fields.
-export const NEURALWATT_MODELS: ProviderModelConfig[] = [
-  // DeepSeek V4 Flash - DeepSeek
-  {
-    id: "deepseek-v4-flash",
-    name: "DeepSeek V4 Flash",
-    reasoning: true,
-    input: ["text"],
-    cost: {
-      input: 0.104,
-      output: 0.207,
-      cacheRead: 0.026,
-      cacheWrite: 0,
-    },
-    contextWindow: 1048560,
-    maxTokens: 65536,
-    thinkingLevelMap: {
-      off: "none",
-      minimal: "low",
-      low: "low",
-      medium: "medium",
-      high: "high",
-      xhigh: null,
-      max: "max",
-    },
-    compat: {
-      supportsDeveloperRole: false,
-      maxTokensField: "max_tokens",
-      requiresReasoningContentOnAssistantMessages: true,
-    },
+// Public models returned by https://api.neuralwatt.com/v1/models.
+// Pricing, capabilities, and limits are sourced from the API metadata fields;
+// `maxTokens` is `metadata.limits.max_output_tokens ?? max_model_len`.
+//
+// Models are declared per family so every variant (`-fast`, `-flex`, `-short`)
+// inherits the family's pricing, modalities, and thinking levels. See
+// `models.test.ts` for the drift check against the live catalog.
+
+// GLM natively supports `high` and `max` reasoning efforts. `xhigh` is an
+// unsupported hole between them. Pi added the `max` level in 0.80.6.
+const GLM_THINKING: ThinkingLevelMap = {
+  off: "none",
+  minimal: null,
+  low: null,
+  medium: null,
+  high: "high",
+  xhigh: null,
+  max: "max",
+};
+
+// Binary thinking control: expose a single known-good Pi level.
+const BINARY_THINKING: ThinkingLevelMap = {
+  minimal: null,
+  low: null,
+  medium: "medium",
+  high: null,
+  xhigh: null,
+};
+
+const DEEPSEEK_V4_FLASH: NeuralwattModelFamily = {
+  cost: { input: 0.104, output: 0.207, cacheRead: 0.026 },
+  vision: false,
+  thinkingLevelMap: {
+    off: "none",
+    minimal: "low",
+    low: "low",
+    medium: "medium",
+    high: "high",
+    xhigh: null,
+    max: "max",
   },
-  // Gemma 4 31B - Google, served from NVIDIA's NVFP4 checkpoint
-  {
-    id: "gemma-4-31b",
-    name: "Gemma 4 31B",
-    reasoning: false,
-    input: ["text", "image"],
-    cost: {
-      input: 0.144,
-      output: 0.42,
-      cacheRead: 0.036,
-      cacheWrite: 0,
-    },
-    contextWindow: 262128,
-    maxTokens: 16384,
-    compat: {
-      supportsDeveloperRole: false,
-      maxTokensField: "max_tokens",
-    },
-  },
-  // GLM-5.2 - ZhipuAI
-  // Native reasoning tiers: off (none), high, max. Exposes Pi's `max` level
-  // (introduced in Pi 0.80.6) for GLM's top tier; `xhigh` is an unsupported
-  // hole between `high` and `max`.
-  {
-    id: "glm-5.2",
-    name: "GLM-5.2",
-    reasoning: true,
-    input: ["text"],
-    cost: {
-      input: 1.45,
-      output: 4.5,
-      cacheRead: 0.3625,
-      cacheWrite: 0,
-    },
-    contextWindow: 1048560,
-    maxTokens: 65536,
-    thinkingLevelMap: {
-      off: "none",
-      minimal: null,
-      low: null,
-      medium: null,
-      high: "high",
-      xhigh: null,
-      max: "max",
-    },
-    compat: {
-      supportsDeveloperRole: false,
-      maxTokensField: "max_tokens",
-      requiresReasoningContentOnAssistantMessages: true,
-    },
-  },
-  // GLM-5.2 Fast - ZhipuAI
-  {
-    id: "glm-5.2-fast",
-    name: "GLM-5.2 Fast",
-    reasoning: false,
-    input: ["text"],
-    cost: {
-      input: 1.45,
-      output: 4.5,
-      cacheRead: 0.3625,
-      cacheWrite: 0,
-    },
-    contextWindow: 1048560,
-    maxTokens: 65536,
-    compat: {
-      supportsDeveloperRole: false,
-      maxTokensField: "max_tokens",
-    },
-  },
-  // GLM-5.2 Short - ZhipuAI (200K context, bounded reasoning budget)
-  {
-    id: "glm-5.2-short",
-    name: "GLM-5.2 Short",
-    reasoning: true,
-    input: ["text"],
-    cost: {
-      input: 1.45,
-      output: 4.5,
-      cacheRead: 0.3625,
-      cacheWrite: 0,
-    },
-    contextWindow: 199984,
-    maxTokens: 32000,
-    thinkingLevelMap: {
-      off: "none",
-      minimal: null,
-      low: null,
-      medium: null,
-      high: "high",
-      xhigh: null,
-      max: "max",
-    },
-    compat: {
-      supportsDeveloperRole: false,
-      maxTokensField: "max_tokens",
-      requiresReasoningContentOnAssistantMessages: true,
-    },
-  },
-  // GLM-5.2 Short Fast - ZhipuAI (200K context, reasoning disabled)
-  {
-    id: "glm-5.2-short-fast",
-    name: "GLM-5.2 Short Fast",
-    reasoning: false,
-    input: ["text"],
-    cost: {
-      input: 1.45,
-      output: 4.5,
-      cacheRead: 0.3625,
-      cacheWrite: 0,
-    },
-    contextWindow: 199984,
-    maxTokens: 32000,
-    compat: {
-      supportsDeveloperRole: false,
-      maxTokensField: "max_tokens",
-    },
-  },
-  // Kimi K2.6 - MoonshotAI
-  {
-    id: "kimi-k2.6",
-    name: "Kimi K2.6",
-    reasoning: true,
-    input: ["text", "image"],
-    cost: {
-      input: 0.69,
-      output: 3.22,
-      cacheRead: 0.1725,
-      cacheWrite: 0,
-    },
-    contextWindow: 262128,
-    maxTokens: 65536,
-    thinkingLevelMap: {
-      minimal: null,
-      low: null,
-      medium: "medium",
-      high: null,
-      xhigh: null,
-    },
-    compat: {
-      supportsDeveloperRole: false,
-      maxTokensField: "max_tokens",
-      requiresReasoningContentOnAssistantMessages: true,
-    },
-  },
-  // Kimi K2.6 Fast - MoonshotAI
-  {
-    id: "kimi-k2.6-fast",
-    name: "Kimi K2.6 Fast",
-    reasoning: false,
-    input: ["text", "image"],
-    cost: {
-      input: 0.69,
-      output: 3.22,
-      cacheRead: 0.1725,
-      cacheWrite: 0,
-    },
-    contextWindow: 262128,
-    maxTokens: 65536,
-    compat: {
-      supportsDeveloperRole: false,
-      maxTokensField: "max_tokens",
-    },
-  },
-  // Qwen3.5 397B - Qwen
-  {
-    id: "qwen3.5-397b",
-    name: "Qwen3.5 397B",
-    reasoning: true,
-    input: ["text"],
-    cost: {
-      input: 0.69,
-      output: 4.14,
-      cacheRead: 0.1725,
-      cacheWrite: 0,
-    },
-    contextWindow: 262128,
-    maxTokens: 65536,
-    thinkingLevelMap: {
-      minimal: null,
-      low: null,
-      medium: "medium",
-      high: null,
-      xhigh: null,
-    },
-    compat: {
-      supportsDeveloperRole: false,
-      maxTokensField: "max_tokens",
-      requiresReasoningContentOnAssistantMessages: true,
-    },
-  },
-  // Qwen3.5 397B Fast - Qwen
-  {
-    id: "qwen3.5-397b-fast",
-    name: "Qwen3.5 397B Fast",
-    reasoning: false,
-    input: ["text"],
-    cost: {
-      input: 0.69,
-      output: 4.14,
-      cacheRead: 0.1725,
-      cacheWrite: 0,
-    },
-    contextWindow: 262128,
-    maxTokens: 65536,
-    compat: {
-      supportsDeveloperRole: false,
-      maxTokensField: "max_tokens",
-    },
-  },
-  // Qwen3.6 35B - Qwen
-  {
-    id: "qwen3.6-35b",
-    name: "Qwen3.6 35B",
-    reasoning: true,
-    input: ["text", "image"],
-    cost: {
-      input: 0.29,
-      output: 1.15,
-      cacheRead: 0.0725,
-      cacheWrite: 0,
-    },
-    contextWindow: 131056,
-    maxTokens: 65536,
-    thinkingLevelMap: {
-      minimal: null,
-      low: null,
-      medium: "medium",
-      high: null,
-      xhigh: null,
-    },
-    compat: {
-      supportsDeveloperRole: false,
-      maxTokensField: "max_tokens",
-      requiresReasoningContentOnAssistantMessages: true,
-    },
-  },
-  // Kimi K2.7 Code - MoonshotAI
-  {
-    id: "kimi-k2.7-code",
-    name: "Kimi K2.7 Code",
-    reasoning: true,
-    input: ["text", "image"],
-    cost: {
-      input: 0.95,
-      output: 4.0,
-      cacheRead: 0.2375,
-      cacheWrite: 0,
-    },
-    contextWindow: 262128,
-    maxTokens: 65536,
-    thinkingLevelMap: {
-      off: null,
-      minimal: null,
-      low: null,
-      medium: "medium",
-      high: null,
-      xhigh: null,
-    },
-    compat: {
-      supportsDeveloperRole: false,
-      maxTokensField: "max_tokens",
-      requiresReasoningContentOnAssistantMessages: true,
-    },
-  },
-  // GLM-5.2 Short Fast Flex - ZhipuAI (flex variant, reasoning disabled)
-  {
-    id: "glm-5.2-short-fast-flex",
-    name: "GLM-5.2 (short, fast, flex)",
-    reasoning: false,
-    input: ["text"],
-    cost: {
-      input: 1.45,
-      output: 4.5,
-      cacheRead: 0.3625,
-      cacheWrite: 0,
-    },
-    contextWindow: 199984,
-    maxTokens: 65536,
-    compat: {
-      supportsDeveloperRole: false,
-      maxTokensField: "max_tokens",
-    },
-  },
-  // GLM-5.2 Short Flex - ZhipuAI (flex variant)
-  {
-    id: "glm-5.2-short-flex",
-    name: "GLM-5.2 (short, flex)",
-    reasoning: true,
-    input: ["text"],
-    cost: {
-      input: 1.45,
-      output: 4.5,
-      cacheRead: 0.3625,
-      cacheWrite: 0,
-    },
-    contextWindow: 199984,
-    maxTokens: 65536,
-    thinkingLevelMap: {
-      off: "none",
-      minimal: null,
-      low: null,
-      medium: null,
-      high: "high",
-      xhigh: null,
-      max: "max",
-    },
-    compat: {
-      supportsDeveloperRole: false,
-      maxTokensField: "max_tokens",
-      requiresReasoningContentOnAssistantMessages: true,
-    },
-  },
-  // Kimi K2.6 Flex - MoonshotAI (flex variant)
-  {
-    id: "kimi-k2.6-flex",
-    name: "Kimi K2.6 (flex)",
-    reasoning: true,
-    input: ["text", "image"],
-    cost: {
-      input: 0.69,
-      output: 3.22,
-      cacheRead: 0.1725,
-      cacheWrite: 0,
-    },
-    contextWindow: 262128,
-    maxTokens: 65536,
-    thinkingLevelMap: {
-      minimal: null,
-      low: null,
-      medium: "medium",
-      high: null,
-      xhigh: null,
-    },
-    compat: {
-      supportsDeveloperRole: false,
-      maxTokensField: "max_tokens",
-      requiresReasoningContentOnAssistantMessages: true,
-    },
-  },
-  // Kimi K2.7 Code Flex - MoonshotAI (flex variant)
-  {
-    id: "kimi-k2.7-code-flex",
-    name: "Kimi K2.7 Code (flex)",
-    reasoning: true,
-    input: ["text", "image"],
-    cost: {
-      input: 0.95,
-      output: 4.0,
-      cacheRead: 0.2375,
-      cacheWrite: 0,
-    },
-    contextWindow: 262128,
-    maxTokens: 65536,
-    thinkingLevelMap: {
-      off: null,
-      minimal: null,
-      low: null,
-      medium: "medium",
-      high: null,
-      xhigh: null,
-    },
-    compat: {
-      supportsDeveloperRole: false,
-      maxTokensField: "max_tokens",
-      requiresReasoningContentOnAssistantMessages: true,
-    },
-  },
-  // GLM-5.2 Flex - ZhipuAI (flex variant)
-  {
-    id: "glm-5.2-flex",
-    name: "GLM-5.2 (flex)",
-    reasoning: true,
-    input: ["text"],
-    cost: {
-      input: 1.45,
-      output: 4.5,
-      cacheRead: 0.3625,
-      cacheWrite: 0,
-    },
-    contextWindow: 1048560,
-    maxTokens: 65536,
-    thinkingLevelMap: {
-      off: "none",
-      minimal: null,
-      low: null,
-      medium: null,
-      high: "high",
-      xhigh: null,
-      max: "max",
-    },
-    compat: {
-      supportsDeveloperRole: false,
-      maxTokensField: "max_tokens",
-      requiresReasoningContentOnAssistantMessages: true,
-    },
-  },
-  // Qwen3.6 35B Fast - Qwen
-  {
-    id: "qwen3.6-35b-fast",
-    name: "Qwen3.6 35B Fast",
-    reasoning: false,
-    input: ["text", "image"],
-    cost: {
-      input: 0.29,
-      output: 1.15,
-      cacheRead: 0.0725,
-      cacheWrite: 0,
-    },
-    contextWindow: 131056,
-    maxTokens: 65536,
-    compat: {
-      supportsDeveloperRole: false,
-      maxTokensField: "max_tokens",
-    },
-  },
+};
+
+// Google, served from NVIDIA's NVFP4 checkpoint.
+const GEMMA_4: NeuralwattModelFamily = {
+  cost: { input: 0.144, output: 0.42, cacheRead: 0.036 },
+  vision: true,
+};
+
+// ZhipuAI.
+const GLM_5_2: NeuralwattModelFamily = {
+  cost: { input: 1.45, output: 4.5, cacheRead: 0.3625 },
+  vision: false,
+  thinkingLevelMap: GLM_THINKING,
+};
+
+// MoonshotAI.
+const KIMI_K2_6: NeuralwattModelFamily = {
+  cost: { input: 0.69, output: 3.22, cacheRead: 0.1725 },
+  vision: true,
+  thinkingLevelMap: BINARY_THINKING,
+};
+
+// MoonshotAI.
+const KIMI_K2_7_CODE: NeuralwattModelFamily = {
+  cost: { input: 0.95, output: 4.0, cacheRead: 0.2375 },
+  vision: true,
+  thinkingLevelMap: { off: null, ...BINARY_THINKING },
+};
+
+// Qwen.
+const QWEN_3_5_397B: NeuralwattModelFamily = {
+  cost: { input: 0.69, output: 4.14, cacheRead: 0.1725 },
+  vision: false,
+  thinkingLevelMap: BINARY_THINKING,
+};
+
+// Qwen.
+const QWEN_3_6_35B: NeuralwattModelFamily = {
+  cost: { input: 0.29, output: 1.15, cacheRead: 0.0725 },
+  vision: true,
+  thinkingLevelMap: BINARY_THINKING,
+};
+
+const FAMILIES: [NeuralwattModelFamily, NeuralwattVariantSpec[]][] = [
+  [
+    DEEPSEEK_V4_FLASH,
+    [
+      {
+        id: "deepseek-v4-flash",
+        name: "DeepSeek V4 Flash",
+        contextWindow: 1048560,
+        maxOutputTokens: 65536,
+        reasoning: true,
+      },
+    ],
+  ],
+  [
+    GEMMA_4,
+    [
+      {
+        id: "gemma-4-31b",
+        name: "Gemma 4 31B",
+        contextWindow: 262128,
+        maxOutputTokens: 16384,
+        reasoning: false,
+      },
+    ],
+  ],
+  [
+    GLM_5_2,
+    [
+      {
+        id: "glm-5.2",
+        name: "GLM-5.2",
+        contextWindow: 1048560,
+        maxOutputTokens: null,
+        reasoning: true,
+      },
+      {
+        id: "glm-5.2-fast",
+        name: "GLM-5.2 Fast",
+        contextWindow: 1048560,
+        maxOutputTokens: null,
+        reasoning: false,
+      },
+      {
+        id: "glm-5.2-flex",
+        name: "GLM-5.2 (flex)",
+        contextWindow: 1048560,
+        maxOutputTokens: null,
+        reasoning: true,
+      },
+      {
+        id: "glm-5.2-short",
+        name: "GLM-5.2 Short",
+        contextWindow: 199984,
+        maxOutputTokens: 32000,
+        reasoning: true,
+      },
+      {
+        id: "glm-5.2-short-fast",
+        name: "GLM-5.2 Short Fast",
+        contextWindow: 199984,
+        maxOutputTokens: 32000,
+        reasoning: false,
+      },
+      {
+        id: "glm-5.2-short-flex",
+        name: "GLM-5.2 (short, flex)",
+        contextWindow: 199984,
+        maxOutputTokens: 32000,
+        reasoning: true,
+      },
+      {
+        id: "glm-5.2-short-fast-flex",
+        name: "GLM-5.2 (short, fast, flex)",
+        contextWindow: 199984,
+        maxOutputTokens: 32000,
+        reasoning: false,
+      },
+    ],
+  ],
+  [
+    KIMI_K2_6,
+    [
+      {
+        id: "kimi-k2.6",
+        name: "Kimi K2.6",
+        contextWindow: 262128,
+        maxOutputTokens: null,
+        reasoning: true,
+      },
+      {
+        id: "kimi-k2.6-fast",
+        name: "Kimi K2.6 Fast",
+        contextWindow: 262128,
+        maxOutputTokens: null,
+        reasoning: false,
+      },
+      {
+        id: "kimi-k2.6-flex",
+        name: "Kimi K2.6 (flex)",
+        contextWindow: 262128,
+        maxOutputTokens: null,
+        reasoning: true,
+      },
+    ],
+  ],
+  [
+    KIMI_K2_7_CODE,
+    [
+      {
+        id: "kimi-k2.7-code",
+        name: "Kimi K2.7 Code",
+        contextWindow: 262128,
+        maxOutputTokens: null,
+        reasoning: true,
+      },
+      {
+        id: "kimi-k2.7-code-fast",
+        name: "Kimi K2.7 Code Fast",
+        contextWindow: 262128,
+        maxOutputTokens: null,
+        reasoning: false,
+      },
+      {
+        id: "kimi-k2.7-code-flex",
+        name: "Kimi K2.7 Code (flex)",
+        contextWindow: 262128,
+        maxOutputTokens: null,
+        reasoning: true,
+      },
+    ],
+  ],
+  [
+    QWEN_3_5_397B,
+    [
+      {
+        id: "qwen3.5-397b",
+        name: "Qwen3.5 397B",
+        contextWindow: 262128,
+        maxOutputTokens: null,
+        reasoning: true,
+      },
+      {
+        id: "qwen3.5-397b-fast",
+        name: "Qwen3.5 397B Fast",
+        contextWindow: 262128,
+        maxOutputTokens: null,
+        reasoning: false,
+      },
+    ],
+  ],
+  [
+    QWEN_3_6_35B,
+    [
+      {
+        id: "qwen3.6-35b",
+        name: "Qwen3.6 35B",
+        contextWindow: 131056,
+        maxOutputTokens: null,
+        reasoning: true,
+      },
+      {
+        id: "qwen3.6-35b-fast",
+        name: "Qwen3.6 35B Fast",
+        contextWindow: 131056,
+        maxOutputTokens: null,
+        reasoning: false,
+      },
+    ],
+  ],
 ];
+
+// `-flex` variants are not advertised by the public /v1/models response; the
+// drift check in models.test.ts tolerates them instead of failing on them.
+
+export const NEURALWATT_MODELS: ProviderModelConfig[] = FAMILIES.flatMap(
+  ([family, variants]) => buildNeuralwattFamily(family, variants),
+);

--- a/extensions/provider/models/refresh.test.ts
+++ b/extensions/provider/models/refresh.test.ts
@@ -6,13 +6,13 @@ import type {
 } from "@earendil-works/pi-ai";
 import type { ProviderModelConfig } from "@earendil-works/pi-coding-agent";
 import { describe, expect, it } from "vitest";
-import { HIDDEN_NEURALWATT_MODELS } from "./hidden";
+import { EARLY_ACCESS_NEURALWATT_MODELS } from "./early-access";
 import { NEURALWATT_MODELS } from "./public-models";
 import { refreshNeuralwattModels } from "./refresh";
 
-const hiddenModel: ProviderModelConfig = {
-  id: "hidden/model",
-  name: "Hidden Model",
+const earlyAccessModel: ProviderModelConfig = {
+  id: "early-access/model",
+  name: "Early Access Model",
   reasoning: false,
   input: ["text"],
   cost: { input: 1, output: 2, cacheRead: 0, cacheWrite: 0 },
@@ -20,10 +20,12 @@ const hiddenModel: ProviderModelConfig = {
   maxTokens: 8_192,
 };
 
-const kimiK3 = HIDDEN_NEURALWATT_MODELS.find((model) => model.id === "kimi-k3");
+const kimiK3 = EARLY_ACCESS_NEURALWATT_MODELS.find(
+  (model) => model.id === "kimi-k3",
+);
 
 if (!kimiK3) {
-  throw new Error("kimi-k3 hidden model fixture is missing");
+  throw new Error("kimi-k3 early-access model fixture is missing");
 }
 
 function storedModel(model: ProviderModelConfig): Model<Api> {
@@ -58,13 +60,13 @@ function createContext(options?: {
 }
 
 describe("refreshNeuralwattModels", () => {
-  it("persists hardcoded hidden models when discovery is empty", async () => {
+  it("persists hardcoded early-access models when discovery is empty", async () => {
     const { context, writes } = createContext();
 
     const models = await refreshNeuralwattModels(context, {
       includeLegacyModelIds: false,
-      includeHiddenModels: true,
-      loadHidden: async () => [],
+      includeEarlyAccessModels: true,
+      loadEarlyAccess: async () => [],
     });
 
     expect(models).toContainEqual(kimiK3);
@@ -77,8 +79,8 @@ describe("refreshNeuralwattModels", () => {
 
     const models = await refreshNeuralwattModels(context, {
       includeLegacyModelIds: false,
-      includeHiddenModels: true,
-      loadHidden: async () => [],
+      includeEarlyAccessModels: true,
+      loadEarlyAccess: async () => [],
     });
 
     expect(models.find((model) => model.id === "kimi-k3")).toEqual({
@@ -109,27 +111,31 @@ describe("refreshNeuralwattModels", () => {
     });
   });
 
-  it("omits hardcoded hidden models when discovery is disabled", async () => {
+  it("omits hardcoded early-access models when discovery is disabled", async () => {
     const { context } = createContext();
 
     const models = await refreshNeuralwattModels(context, {
       includeLegacyModelIds: false,
-      includeHiddenModels: false,
+      includeEarlyAccessModels: false,
     });
 
     expect(models.some((model) => model.id === kimiK3.id)).toBe(false);
   });
 
-  it("keeps public models authoritative on hidden ID collisions", async () => {
+  it("keeps public models authoritative on early-access ID collisions", async () => {
     const { context } = createContext();
     const publicModel = NEURALWATT_MODELS[0];
     if (!publicModel) throw new Error("public model fixture is missing");
 
     const models = await refreshNeuralwattModels(context, {
       includeLegacyModelIds: false,
-      includeHiddenModels: true,
-      loadHidden: async () => [
-        { ...hiddenModel, id: publicModel.id, name: "Hidden collision" },
+      includeEarlyAccessModels: true,
+      loadEarlyAccess: async () => [
+        {
+          ...earlyAccessModel,
+          id: publicModel.id,
+          name: "Early access collision",
+        },
       ],
     });
 
@@ -138,18 +144,18 @@ describe("refreshNeuralwattModels", () => {
     ]);
   });
 
-  it("restores cached hidden models with current public models offline", async () => {
+  it("restores cached early-access models with current public models offline", async () => {
     const { context, writes } = createContext({
       allowNetwork: false,
-      stored: { models: [storedModel(hiddenModel)], checkedAt: 1 },
+      stored: { models: [storedModel(earlyAccessModel)], checkedAt: 1 },
     });
 
     const models = await refreshNeuralwattModels(context, {
       includeLegacyModelIds: false,
-      includeHiddenModels: true,
+      includeEarlyAccessModels: true,
     });
 
-    expect(models.some((model) => model.id === hiddenModel.id)).toBe(true);
+    expect(models.some((model) => model.id === earlyAccessModel.id)).toBe(true);
     expect(models.length).toBeGreaterThan(1);
     expect(writes).toHaveLength(0);
   });
@@ -159,46 +165,48 @@ describe("refreshNeuralwattModels", () => {
 
     const models = await refreshNeuralwattModels(context, {
       includeLegacyModelIds: false,
-      includeHiddenModels: true,
-      loadHidden: async () => [hiddenModel],
+      includeEarlyAccessModels: true,
+      loadEarlyAccess: async () => [earlyAccessModel],
     });
 
     expect(writes).toHaveLength(1);
     expect(writes[0]?.models).toHaveLength(models.length);
-    expect(writes[0]?.models.some((model) => model.id === hiddenModel.id)).toBe(
-      true,
-    );
-    expect(writes[0]?.models.some((model) => model.id !== hiddenModel.id)).toBe(
-      true,
-    );
+    expect(
+      writes[0]?.models.some((model) => model.id === earlyAccessModel.id),
+    ).toBe(true);
+    expect(
+      writes[0]?.models.some((model) => model.id !== earlyAccessModel.id),
+    ).toBe(true);
   });
 
-  it("purges hidden models when discovery is disabled", async () => {
+  it("purges early-access models when discovery is disabled", async () => {
     const { context, writes } = createContext({
-      stored: { models: [storedModel(hiddenModel)], checkedAt: 1 },
+      stored: { models: [storedModel(earlyAccessModel)], checkedAt: 1 },
     });
 
     const models = await refreshNeuralwattModels(context, {
       includeLegacyModelIds: false,
-      includeHiddenModels: false,
+      includeEarlyAccessModels: false,
     });
 
-    expect(models.some((model) => model.id === hiddenModel.id)).toBe(false);
-    expect(writes[0]?.models).toHaveLength(models.length);
-    expect(writes[0]?.models.some((model) => model.id === hiddenModel.id)).toBe(
+    expect(models.some((model) => model.id === earlyAccessModel.id)).toBe(
       false,
     );
+    expect(writes[0]?.models).toHaveLength(models.length);
+    expect(
+      writes[0]?.models.some((model) => model.id === earlyAccessModel.id),
+    ).toBe(false);
   });
 
   it("preserves the stale cache when a network refresh fails", async () => {
-    const stored = { models: [storedModel(hiddenModel)], checkedAt: 1 };
+    const stored = { models: [storedModel(earlyAccessModel)], checkedAt: 1 };
     const { context, writes } = createContext({ stored });
 
     await expect(
       refreshNeuralwattModels(context, {
         includeLegacyModelIds: false,
-        includeHiddenModels: true,
-        loadHidden: async () => undefined,
+        includeEarlyAccessModels: true,
+        loadEarlyAccess: async () => undefined,
       }),
     ).rejects.toThrow("catalog refresh failed");
     expect(writes).toHaveLength(0);
@@ -206,8 +214,8 @@ describe("refreshNeuralwattModels", () => {
     const offline = createContext({ allowNetwork: false, stored });
     const models = await refreshNeuralwattModels(offline.context, {
       includeLegacyModelIds: false,
-      includeHiddenModels: true,
+      includeEarlyAccessModels: true,
     });
-    expect(models.some((model) => model.id === hiddenModel.id)).toBe(true);
+    expect(models.some((model) => model.id === earlyAccessModel.id)).toBe(true);
   });
 });

--- a/extensions/provider/models/refresh.test.ts
+++ b/extensions/provider/models/refresh.test.ts
@@ -93,7 +93,7 @@ describe("refreshNeuralwattModels", () => {
         cacheWrite: 0,
       },
       contextWindow: 1048560,
-      maxTokens: 65536,
+      maxTokens: 1048560,
       thinkingLevelMap: {
         minimal: null,
         low: null,

--- a/extensions/provider/models/refresh.ts
+++ b/extensions/provider/models/refresh.ts
@@ -5,7 +5,10 @@ import type {
   RefreshModelsContext,
 } from "@earendil-works/pi-ai";
 import type { ProviderModelConfig } from "@earendil-works/pi-coding-agent";
-import { HIDDEN_NEURALWATT_MODELS, loadHiddenModels } from "./hidden";
+import {
+  EARLY_ACCESS_NEURALWATT_MODELS,
+  loadEarlyAccessModels,
+} from "./early-access";
 import { buildLegacyNeuralwattModels } from "./legacy";
 import { NEURALWATT_MODELS } from "./public-models";
 
@@ -15,8 +18,8 @@ const API = "openai-completions" as const;
 
 export interface RefreshNeuralwattModelsOptions {
   includeLegacyModelIds: boolean;
-  includeHiddenModels: boolean;
-  loadHidden?: typeof loadHiddenModels;
+  includeEarlyAccessModels: boolean;
+  loadEarlyAccess?: typeof loadEarlyAccessModels;
 }
 
 function configuredModels(
@@ -59,31 +62,31 @@ function toProviderModel(model: Model<Api>): ProviderModelConfig {
   };
 }
 
-function dedupeHiddenModels(
-  hiddenModels: ProviderModelConfig[],
+function dedupeEarlyAccessModels(
+  earlyAccessModels: ProviderModelConfig[],
   baselineModels: ProviderModelConfig[],
 ): ProviderModelConfig[] {
   const baselineIds = new Set(baselineModels.map((model) => model.id));
-  return hiddenModels.filter((model) => !baselineIds.has(model.id));
+  return earlyAccessModels.filter((model) => !baselineIds.has(model.id));
 }
 
-function configuredHiddenModels(
+function configuredEarlyAccessModels(
   discoveredModels: ProviderModelConfig[],
   baselineModels: ProviderModelConfig[],
 ): ProviderModelConfig[] {
   const hardcodedIds = new Set(
-    HIDDEN_NEURALWATT_MODELS.map((model) => model.id),
+    EARLY_ACCESS_NEURALWATT_MODELS.map((model) => model.id),
   );
-  return dedupeHiddenModels(
+  return dedupeEarlyAccessModels(
     [
-      ...HIDDEN_NEURALWATT_MODELS,
+      ...EARLY_ACCESS_NEURALWATT_MODELS,
       ...discoveredModels.filter((model) => !hardcodedIds.has(model.id)),
     ],
     baselineModels,
   );
 }
 
-function cachedHiddenModels(
+function cachedEarlyAccessModels(
   stored: ModelsStoreEntry | undefined,
 ): ProviderModelConfig[] {
   if (!stored) return [];
@@ -115,16 +118,16 @@ export async function refreshNeuralwattModels(
   const baseline = configuredModels(options.includeLegacyModelIds);
   const stored = await context.store.read();
 
-  if (!options.includeHiddenModels) {
+  if (!options.includeEarlyAccessModels) {
     await persistModels(context, baseline);
     return baseline;
   }
 
-  const cachedHidden = configuredHiddenModels(
-    cachedHiddenModels(stored),
+  const cachedEarlyAccess = configuredEarlyAccessModels(
+    cachedEarlyAccessModels(stored),
     baseline,
   );
-  const cachedCatalog = [...baseline, ...cachedHidden];
+  const cachedCatalog = [...baseline, ...cachedEarlyAccess];
 
   if (!context.allowNetwork || context.signal?.aborted) {
     return cachedCatalog;
@@ -134,16 +137,19 @@ export async function refreshNeuralwattModels(
     context.credential?.type === "api_key" ? context.credential.key : undefined;
   if (!apiKey) return cachedCatalog;
 
-  const hidden = await (options.loadHidden ?? loadHiddenModels)(
+  const earlyAccess = await (options.loadEarlyAccess ?? loadEarlyAccessModels)(
     apiKey,
     context.signal,
   );
   if (context.signal?.aborted) return cachedCatalog;
-  if (!hidden) {
+  if (!earlyAccess) {
     throw new Error("Neuralwatt model catalog refresh failed");
   }
 
-  const catalog = [...baseline, ...configuredHiddenModels(hidden, baseline)];
+  const catalog = [
+    ...baseline,
+    ...configuredEarlyAccessModels(earlyAccess, baseline),
+  ];
   await persistModels(context, catalog);
   return catalog;
 }

--- a/schema.json
+++ b/schema.json
@@ -31,8 +31,8 @@
     "NeuralwattProviderConfig": {
       "additionalProperties": false,
       "properties": {
-        "includeHiddenModels": {
-          "description": "Include hidden Neuralwatt models discovered via the authenticated API.",
+        "includeEarlyAccessModels": {
+          "description": "Include early-access Neuralwatt models discovered via the authenticated API.",
           "type": "boolean"
         },
         "includeLegacyModelIds": {

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -3,7 +3,7 @@ import type { ResolvedNeuralwattConfig } from "./types";
 export const DEFAULT_CONFIG: ResolvedNeuralwattConfig = {
   provider: {
     includeLegacyModelIds: false,
-    includeHiddenModels: false,
+    includeEarlyAccessModels: false,
   },
   quotaCommand: {
     enabled: true,

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,9 +1,4 @@
 export { DEFAULT_CONFIG } from "./defaults";
 export { configLoader } from "./loader";
 export { migrations } from "./migration";
-export type {
-  NeuralwattConfig,
-  NeuralwattRawConfig,
-  PreviousNeuralwattConfig,
-  ResolvedNeuralwattConfig,
-} from "./types";
+export type { NeuralwattConfig, ResolvedNeuralwattConfig } from "./types";

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -2,70 +2,44 @@ import { buildSchemaUrl, ConfigLoader } from "@aliou/pi-utils-settings";
 import packageJson from "../../package.json";
 import { DEFAULT_CONFIG } from "./defaults";
 import { migrations } from "./migration";
-import type { NeuralwattRawConfig, ResolvedNeuralwattConfig } from "./types";
+import type { NeuralwattConfig, ResolvedNeuralwattConfig } from "./types";
 
-type ConfigRecord = Record<string, unknown>;
-
-type MaybeEnabled = { enabled?: boolean };
-type MaybeProvider = {
-  includeLegacyModelIds?: boolean;
-  includeHiddenModels?: boolean;
-};
-
-function featureEnabled(value: unknown, fallback: boolean): boolean {
-  if (typeof value === "boolean") return value;
-  if (value && typeof value === "object") {
-    const { enabled } = value as MaybeEnabled;
-    if (typeof enabled === "boolean") return enabled;
-  }
-  return fallback;
-}
-
+/**
+ * Fill in every field the rest of the code reads. Migrations already normalized
+ * the on-disk shape, so this only merges partial sections with the defaults.
+ */
 function normalizeResolvedConfig(
   resolved: ResolvedNeuralwattConfig,
 ): ResolvedNeuralwattConfig {
-  const record = resolved as unknown as ConfigRecord;
-  const provider =
-    record.provider && typeof record.provider === "object"
-      ? (record.provider as MaybeProvider)
-      : {};
+  const config = resolved as Partial<ResolvedNeuralwattConfig>;
 
   return {
     provider: {
       includeLegacyModelIds:
-        provider.includeLegacyModelIds ??
-        (typeof record.includeLegacyModelIds === "boolean"
-          ? record.includeLegacyModelIds
-          : DEFAULT_CONFIG.provider.includeLegacyModelIds),
-      includeHiddenModels:
-        provider.includeHiddenModels ??
-        (typeof record.includeHiddenModels === "boolean"
-          ? record.includeHiddenModels
-          : DEFAULT_CONFIG.provider.includeHiddenModels),
+        config.provider?.includeLegacyModelIds ??
+        DEFAULT_CONFIG.provider.includeLegacyModelIds,
+      includeEarlyAccessModels:
+        config.provider?.includeEarlyAccessModels ??
+        DEFAULT_CONFIG.provider.includeEarlyAccessModels,
     },
     quotaCommand: {
-      enabled: featureEnabled(
-        record.quotaCommand,
-        DEFAULT_CONFIG.quotaCommand.enabled,
-      ),
+      enabled:
+        config.quotaCommand?.enabled ?? DEFAULT_CONFIG.quotaCommand.enabled,
     },
     quotaWarnings: {
-      enabled: featureEnabled(
-        record.quotaWarnings,
-        DEFAULT_CONFIG.quotaWarnings.enabled,
-      ),
+      enabled:
+        config.quotaWarnings?.enabled ?? DEFAULT_CONFIG.quotaWarnings.enabled,
     },
     subBarIntegration: {
-      enabled: featureEnabled(
-        record.subBarIntegration,
+      enabled:
+        config.subBarIntegration?.enabled ??
         DEFAULT_CONFIG.subBarIntegration.enabled,
-      ),
     },
   };
 }
 
 export const configLoader = new ConfigLoader<
-  NeuralwattRawConfig,
+  NeuralwattConfig,
   ResolvedNeuralwattConfig
 >("neuralwatt", DEFAULT_CONFIG, {
   migrations,

--- a/src/config/migration/01-disable-legacy-model-ids-by-default.ts
+++ b/src/config/migration/01-disable-legacy-model-ids-by-default.ts
@@ -1,7 +1,5 @@
 import type { Migration } from "@aliou/pi-utils-settings";
-import type { NeuralwattConfig, PreviousNeuralwattConfig } from "../types";
-
-type MigrationConfig = PreviousNeuralwattConfig | NeuralwattConfig;
+import type { NeuralwattConfig } from "../types";
 
 type MutableConfigRecord = Record<string, unknown>;
 
@@ -9,7 +7,7 @@ function hasOwn(record: MutableConfigRecord, key: string): boolean {
   return Object.hasOwn(record, key);
 }
 
-function hasNestedConfig(config: MigrationConfig): boolean {
+function hasNestedConfig(config: NeuralwattConfig): boolean {
   return Boolean(
     ("provider" in config && config.provider) ||
       (config.quotaCommand && typeof config.quotaCommand === "object") ||
@@ -20,25 +18,25 @@ function hasNestedConfig(config: MigrationConfig): boolean {
 }
 
 function isPreviousConfigWithoutLegacyDefault(
-  config: MigrationConfig,
-): config is PreviousNeuralwattConfig {
+  config: NeuralwattConfig,
+): boolean {
   return (
     !hasNestedConfig(config) &&
     !hasOwn(config as MutableConfigRecord, "includeLegacyModelIds")
   );
 }
 
-export const disableLegacyModelIdsByDefaultMigration: Migration<MigrationConfig> =
+export const disableLegacyModelIdsByDefaultMigration: Migration<NeuralwattConfig> =
   {
     name: "disable-legacy-model-ids-by-default",
     shouldRun: isPreviousConfigWithoutLegacyDefault,
     message:
       "[neuralwatt] legacy model IDs (ids including the provider and the quantization) are disabled by default. You can enable them with /neuralwatt:settings.",
-    run: (config) => {
-      const previous = config as PreviousNeuralwattConfig;
-      return {
-        ...previous,
+    // Flat config: `includeLegacyModelIds` sits at the top level here. Migration
+    // 02 moves it under `provider`.
+    run: (config) =>
+      ({
+        ...config,
         includeLegacyModelIds: false,
-      };
-    },
+      }) as unknown as NeuralwattConfig,
   };

--- a/src/config/migration/02-flat-to-nested-config.ts
+++ b/src/config/migration/02-flat-to-nested-config.ts
@@ -3,11 +3,27 @@ import { copyFile } from "node:fs/promises";
 import { basename, dirname, join } from "node:path";
 import type { Migration } from "@aliou/pi-utils-settings";
 import packageJson from "../../../package.json";
-import type { NeuralwattConfig, PreviousNeuralwattConfig } from "../types";
+import type { NeuralwattConfig } from "../types";
 
-type MigrationConfig = PreviousNeuralwattConfig | NeuralwattConfig;
+/** The original flat config, replaced by per-feature sections. */
+interface FlatNeuralwattConfig {
+  /** Show the quota command (/neuralwatt:quota). */
+  quotaCommand?: boolean;
 
-type FlatConfigKey = keyof Omit<PreviousNeuralwattConfig, "$schema">;
+  /** Show quota warnings when credits or energy are low. */
+  quotaWarnings?: boolean;
+
+  /** Show usage in the sub-bar / status bar. */
+  subBarIntegration?: boolean;
+
+  /** Include legacy Neuralwatt model IDs in the model picker. */
+  includeLegacyModelIds?: boolean;
+
+  /** Renamed to `provider.includeEarlyAccessModels` by migration 03. */
+  includeHiddenModels?: boolean;
+}
+
+type FlatConfigKey = keyof FlatNeuralwattConfig;
 type MutableConfigRecord = Record<string, unknown>;
 
 const FLAT_CONFIG_KEYS = [
@@ -34,9 +50,7 @@ function isObject(value: unknown): value is Record<string, unknown> {
   return Boolean(value && typeof value === "object" && !Array.isArray(value));
 }
 
-function isPreviousConfig(
-  config: MigrationConfig,
-): config is PreviousNeuralwattConfig {
+function isPreviousConfig(config: NeuralwattConfig): boolean {
   const record = config as MutableConfigRecord;
   return FLAT_CONFIG_KEYS.some((key) => typeof record[key] === "boolean");
 }
@@ -64,16 +78,15 @@ export async function backupConfig(filePath: string): Promise<void> {
   }
 }
 
-export const flatToNestedConfigMigration: Migration<MigrationConfig> = {
+export const flatToNestedConfigMigration: Migration<NeuralwattConfig> = {
   name: "flat-to-nested-config",
   shouldRun: isPreviousConfig,
   message: FLAT_CONFIG_MIGRATION_MESSAGE,
   run: async (config, filePath) => {
     await backupConfig(filePath);
 
-    const previous = config as PreviousNeuralwattConfig;
-    const nestedConfig = config as NeuralwattConfig;
-    const record = previous as MutableConfigRecord;
+    const nestedConfig = config;
+    const record = config as unknown as MutableConfigRecord;
     const nested: NeuralwattConfig = {
       provider: {
         ...(isObject(nestedConfig.provider) ? nestedConfig.provider : {}),
@@ -100,14 +113,18 @@ export const flatToNestedConfigMigration: Migration<MigrationConfig> = {
       };
     }
 
-    const includeHiddenModels = booleanValue(record, "includeHiddenModels");
+    // Flat configs predate the rename, so they still use `includeHiddenModels`.
+    const includeEarlyAccessModels = booleanValue(
+      record,
+      "includeHiddenModels",
+    );
     if (
-      nested.provider?.includeHiddenModels === undefined &&
-      includeHiddenModels !== undefined
+      nested.provider?.includeEarlyAccessModels === undefined &&
+      includeEarlyAccessModels !== undefined
     ) {
       nested.provider = {
         ...nested.provider,
-        includeHiddenModels,
+        includeEarlyAccessModels,
       };
     }
 

--- a/src/config/migration/03-rename-hidden-to-early-access.ts
+++ b/src/config/migration/03-rename-hidden-to-early-access.ts
@@ -1,0 +1,47 @@
+import type { Migration } from "@aliou/pi-utils-settings";
+import type { NeuralwattConfig } from "../types";
+
+/** The provider section before `includeHiddenModels` was renamed. */
+interface PreviousProviderConfig {
+  includeLegacyModelIds?: boolean;
+  includeEarlyAccessModels?: boolean;
+  /** Renamed to `includeEarlyAccessModels`. */
+  includeHiddenModels?: boolean;
+}
+
+function previousProvider(
+  config: NeuralwattConfig,
+): PreviousProviderConfig | undefined {
+  if (!("provider" in config)) return undefined;
+  const { provider } = config;
+  return provider && typeof provider === "object"
+    ? (provider as PreviousProviderConfig)
+    : undefined;
+}
+
+/**
+ * `provider.includeHiddenModels` was renamed to `provider.includeEarlyAccessModels`.
+ * The models were never hidden, only released to authorized accounts first.
+ */
+export const renameHiddenToEarlyAccessMigration: Migration<NeuralwattConfig> = {
+  name: "rename-hidden-models-to-early-access",
+  shouldRun: (config) =>
+    previousProvider(config)?.includeHiddenModels !== undefined,
+  message:
+    "[neuralwatt] `provider.includeHiddenModels` is now `provider.includeEarlyAccessModels`.",
+  run: (config) => {
+    const provider = previousProvider(config);
+    if (!provider) return config;
+
+    const { includeHiddenModels, ...rest } = provider;
+
+    return {
+      ...config,
+      provider: {
+        ...rest,
+        includeEarlyAccessModels:
+          rest.includeEarlyAccessModels ?? includeHiddenModels,
+      },
+    };
+  },
+};

--- a/src/config/migration/index.test.ts
+++ b/src/config/migration/index.test.ts
@@ -5,12 +5,12 @@ import { ConfigLoader } from "@aliou/pi-utils-settings";
 import { afterEach, describe, expect, it } from "vitest";
 import packageJson from "../../../package.json";
 import { DEFAULT_CONFIG } from "../defaults";
-import type {
-  NeuralwattConfig,
-  NeuralwattRawConfig,
-  ResolvedNeuralwattConfig,
-} from "../types";
-import { backupConfig, flatToNestedConfigMigration } from "./index";
+import type { NeuralwattConfig, ResolvedNeuralwattConfig } from "../types";
+import {
+  backupConfig,
+  flatToNestedConfigMigration,
+  renameHiddenToEarlyAccessMigration,
+} from "./index";
 
 const tempDirs: string[] = [];
 
@@ -27,7 +27,7 @@ async function runFlatMigration(
 ): Promise<NeuralwattConfig> {
   const { filePath } = await tempConfigFile();
   return flatToNestedConfigMigration.run(
-    config as NeuralwattRawConfig,
+    config as NeuralwattConfig,
     filePath,
   ) as Promise<NeuralwattConfig>;
 }
@@ -36,6 +36,51 @@ afterEach(async () => {
   await Promise.all(
     tempDirs.splice(0).map((dir) => rm(dir, { recursive: true })),
   );
+});
+
+describe("renameHiddenToEarlyAccessMigration", () => {
+  const run = async (config: Record<string, unknown>) =>
+    (await renameHiddenToEarlyAccessMigration.run(
+      config as NeuralwattConfig,
+      "neuralwatt.json",
+    )) as NeuralwattConfig;
+
+  it("runs only when the pre-rename key is present", () => {
+    const shouldRun = (config: Record<string, unknown>) =>
+      renameHiddenToEarlyAccessMigration.shouldRun(config as NeuralwattConfig);
+
+    expect(shouldRun({ provider: { includeHiddenModels: true } })).toBe(true);
+    expect(shouldRun({ provider: { includeEarlyAccessModels: true } })).toBe(
+      false,
+    );
+    expect(shouldRun({ quotaCommand: { enabled: true } })).toBe(false);
+    expect(shouldRun({ includeHiddenModels: true })).toBe(false);
+  });
+
+  it("renames the key and keeps other settings", async () => {
+    const migrated = await run({
+      provider: { includeHiddenModels: true, includeLegacyModelIds: true },
+      quotaCommand: { enabled: false },
+    });
+
+    expect(migrated).toEqual({
+      provider: {
+        includeEarlyAccessModels: true,
+        includeLegacyModelIds: true,
+      },
+      quotaCommand: { enabled: false },
+    });
+  });
+
+  it("keeps an existing new key and drops the old one", async () => {
+    const migrated = await run({
+      provider: { includeHiddenModels: true, includeEarlyAccessModels: false },
+    });
+
+    expect(migrated).toEqual({
+      provider: { includeEarlyAccessModels: false },
+    });
+  });
 });
 
 describe("flatToNestedConfigMigration", () => {
@@ -51,7 +96,7 @@ describe("flatToNestedConfigMigration", () => {
     expect(migrated).toEqual({
       provider: {
         includeLegacyModelIds: true,
-        includeHiddenModels: true,
+        includeEarlyAccessModels: true,
       },
       quotaCommand: { enabled: false },
       quotaWarnings: { enabled: true },
@@ -63,13 +108,13 @@ describe("flatToNestedConfigMigration", () => {
     const mixed = {
       quotaWarnings: false,
       includeHiddenModels: false,
-      provider: { includeHiddenModels: true },
+      provider: { includeEarlyAccessModels: true },
       quotaCommand: { enabled: true },
     } as Record<string, unknown>;
     const migrated = await runFlatMigration(mixed);
 
     expect(migrated).toEqual({
-      provider: { includeHiddenModels: true },
+      provider: { includeEarlyAccessModels: true },
       quotaCommand: { enabled: true },
       quotaWarnings: { enabled: false },
       subBarIntegration: {},
@@ -79,7 +124,7 @@ describe("flatToNestedConfigMigration", () => {
   it("creates a backup next to the migrated config", async () => {
     const { dir, filePath } = await tempConfigFile();
     await flatToNestedConfigMigration.run(
-      { quotaCommand: false } as unknown as NeuralwattRawConfig,
+      { quotaCommand: false } as unknown as NeuralwattConfig,
       filePath,
     );
 
@@ -111,7 +156,7 @@ describe("flatToNestedConfigMigration", () => {
 
     await expect(
       flatToNestedConfigMigration.run(
-        { quotaCommand: false } as NeuralwattRawConfig,
+        { quotaCommand: false } as unknown as NeuralwattConfig,
         join(dir, "missing.json"),
       ),
     ).rejects.toThrow();
@@ -132,7 +177,7 @@ describe("flatToNestedConfigMigration", () => {
     try {
       process.chdir(dir);
       const loader = new ConfigLoader<
-        NeuralwattRawConfig,
+        NeuralwattConfig,
         ResolvedNeuralwattConfig
       >("neuralwatt", DEFAULT_CONFIG, {
         scopes: ["local"],

--- a/src/config/migration/index.ts
+++ b/src/config/migration/index.ts
@@ -1,16 +1,19 @@
 import type { Migration } from "@aliou/pi-utils-settings";
-import type { NeuralwattRawConfig } from "../types";
+import type { NeuralwattConfig } from "../types";
 
 export { disableLegacyModelIdsByDefaultMigration } from "./01-disable-legacy-model-ids-by-default";
 export {
   backupConfig,
   flatToNestedConfigMigration,
 } from "./02-flat-to-nested-config";
+export { renameHiddenToEarlyAccessMigration } from "./03-rename-hidden-to-early-access";
 
 import { disableLegacyModelIdsByDefaultMigration } from "./01-disable-legacy-model-ids-by-default";
 import { flatToNestedConfigMigration } from "./02-flat-to-nested-config";
+import { renameHiddenToEarlyAccessMigration } from "./03-rename-hidden-to-early-access";
 
-export const migrations: Migration<NeuralwattRawConfig>[] = [
+export const migrations: Migration<NeuralwattConfig>[] = [
   disableLegacyModelIdsByDefaultMigration,
   flatToNestedConfigMigration,
+  renameHiddenToEarlyAccessMigration,
 ];

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -1,29 +1,9 @@
-export interface PreviousNeuralwattConfig {
-  /** $schema URL for editor autocomplete. */
-  $schema?: string;
-
-  /** Show the quota command (/neuralwatt:quota). */
-  quotaCommand?: boolean;
-
-  /** Show quota warnings when credits or energy are low. */
-  quotaWarnings?: boolean;
-
-  /** Show usage in the sub-bar / status bar. */
-  subBarIntegration?: boolean;
-
-  /** Include legacy Neuralwatt model IDs in the model picker. */
-  includeLegacyModelIds?: boolean;
-
-  /** Include hidden Neuralwatt models discovered via the authenticated API. */
-  includeHiddenModels?: boolean;
-}
-
 export interface NeuralwattProviderConfig {
   /** Include legacy Neuralwatt model IDs in the model picker. */
   includeLegacyModelIds?: boolean;
 
-  /** Include hidden Neuralwatt models discovered via the authenticated API. */
-  includeHiddenModels?: boolean;
+  /** Include early-access Neuralwatt models discovered via the authenticated API. */
+  includeEarlyAccessModels?: boolean;
 }
 
 export interface NeuralwattQuotaCommandConfig {
@@ -58,12 +38,10 @@ export interface NeuralwattConfig {
   subBarIntegration?: NeuralwattSubBarIntegrationConfig;
 }
 
-export type NeuralwattRawConfig = PreviousNeuralwattConfig | NeuralwattConfig;
-
 export interface ResolvedNeuralwattConfig {
   provider: {
     includeLegacyModelIds: boolean;
-    includeHiddenModels: boolean;
+    includeEarlyAccessModels: boolean;
   };
   quotaCommand: {
     enabled: boolean;


### PR DESCRIPTION
> [!NOTE]
> Created by Pi (`anthropic/claude-opus-5`) Eval: 👎

Three related fixes to the Neuralwatt model catalog, split into one commit each.

## `maxTokens` ignored the API

`maxTokens` fell back to `65536` whenever the API reported
`metadata.limits.max_output_tokens` as `null`. Null does not mean "unknown", it
means output is bounded only by the context window. The correct rule is
`max_output_tokens ?? max_model_len`, which is also how models.dev records the
same Neuralwatt models. Pi only uses `maxTokens` to pick the request field and
to clamp the compaction budget, so large values are safe.

Raised: `glm-5.2{,-fast,-flex}` (1048560), `kimi-k2.6{,-fast,-flex}`,
`kimi-k2.7-code{,-flex}`, `qwen3.5-397b{,-fast}` (262128), `qwen3.6-35b{,-fast}`
(131056), early-access `kimi-k3` (1048560).
Lowered: `glm-5.2-short-flex` and `glm-5.2-short-fast-flex` to their real 32000
cap.
Added: `kimi-k2.7-code-fast`, which the public catalog now advertises.

`public-models.ts` is now a family/variant table instead of 451 lines of copied
literals. A family holds the pricing, modalities, and thinking levels its
variants share; a variant declares only what differs. Early-access discovery
uses the same builder, so the limit rule and the compat defaults exist once.

## Flex variants were priced as standard

Flex is billed at 65% of standard (35% off), so every `-flex` model overstated
its cost by more than a third. Applied through a `costMultiplier` on the
variant.

Caveat worth knowing: the discount requires streaming. A non-streaming request
to a `-flex` model silently falls back to the standard tier and the standard
price and reports `service_tier: "standard"`. The model config cannot express
that, so it is documented instead.

## "Hidden models" was the wrong name

These models are not hidden, they are pre-release. `provider.includeHiddenModels`
is now `provider.includeEarlyAccessModels`, with a migration that rewrites
existing configs on load.

Since the loader migrates the file before anything else reads it, the rest of
the code only needs the current shape. This removes `NeuralwattRawConfig` and
the flat-config handling that had leaked into the loader and the settings
command; each migration now declares the old shape it needs.

## Verification

`pnpm typecheck`, `pnpm lint`, `pnpm test` (65 tests), and `pnpm check:schema`
pass on each commit. The live-catalog drift test now enforces the `maxTokens`
rule in the null case and skips when the API is unreachable rather than failing
offline runs, but still fails on an HTTP error.

Not verified: Flex pricing could not be confirmed against `/v1/models`, since
`-flex` models are not returned to my API key in either the authenticated or
unauthenticated view. The 65% figure comes from the Flex tier docs.
