### PR TITLE
fix: scope quota listeners to active session to avoid stale ctx (#53)

### DIFF
--- a/.changeset/stale-ctx-quota-listeners.md
+++ b/.changeset/stale-ctx-quota-listeners.md
@@ -1,0 +1,5 @@
+---
+"@aliou/pi-neuralwatt": patch
+---
+
+Fix stale extension context after session replacement in quota-warnings and sub-bar-integration (issue #53)

--- a/extensions/_shared/stale-ctx.ts
+++ b/extensions/_shared/stale-ctx.ts
@@ -1,0 +1,14 @@
+/**
+ * The `assertActive` error Pi throws when an `ExtensionContext` captured by a
+ * long-lived listener outlives its session.
+ *
+ * In-process subagents (e.g. `@gotgenes/pi-subagents`) create a sibling
+ * `AgentSession` in the same process. Its `session.dispose()` invalidates the
+ * child's `ExtensionRunner` (so any captured child ctx throws on access) but
+ * does NOT emit `session_shutdown`, so async work still draining on the
+ * child's event bus — the SSE quota tee reader — can fire a quota-updates
+ * listener after the child ctx is already stale.
+ */
+export function isStaleExtensionCtxError(err: unknown): boolean {
+  return err instanceof Error && /extension ctx is stale/i.test(err.message);
+}

--- a/extensions/quota-warnings/index.test.ts
+++ b/extensions/quota-warnings/index.test.ts
@@ -1,0 +1,248 @@
+import type {
+  ExtensionAPI,
+  ExtensionContext,
+} from "@earendil-works/pi-coding-agent";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NEURALWATT_QUOTAS_UPDATED_EVENT } from "../../src/events";
+import type { NeuralwattQuotas } from "../../src/types/quota-api";
+import factory from "./index";
+import { clearAlertState } from "./notifier";
+
+/**
+ * The config module is stubbed so the factory never touches disk. The loader
+ * is a singleton (same reference on every call) so runtime config-toggle
+ * listeners behave as in production.
+ */
+vi.mock("../../src/config", () => {
+  const configLoader = {
+    load: vi.fn(async () => {}),
+    getConfig: () => ({ quotaWarnings: { enabled: true } }),
+  };
+  return { configLoader };
+});
+
+/**
+ * Fake ExtensionContext. `.model` is a getter that mirrors real Pi: it throws
+ * once the ctx is deactivated (`__deactivate()`), simulating "ctx is stale
+ * after session replacement". `ui.notify` records calls for assertion.
+ */
+interface FakeCtx {
+  calls: { level: string; msg: string }[];
+  __deactivate(): void;
+}
+
+function fakeCtx(provider = "neuralwatt"): ExtensionContext & FakeCtx {
+  const state = { provider, active: true };
+  const calls: { level: string; msg: string }[] = [];
+  const ctx = {
+    calls,
+    hasUI: true,
+    get model() {
+      if (!state.active) {
+        throw new Error(
+          "This extension ctx is stale after session replacement or reload.",
+        );
+      }
+      return { provider: state.provider };
+    },
+    ui: {
+      notify: (msg: string, level: "info" | "warning" | "error") => {
+        calls.push({ level, msg });
+      },
+    },
+    __deactivate() {
+      state.active = false;
+    },
+  };
+  return ctx as unknown as ExtensionContext & FakeCtx;
+}
+
+/** A NeuralwattQuotas payload whose balance credits trigger a low-quota notify. */
+function lowQuotas(): NeuralwattQuotas {
+  return {
+    snapshot_at: "2026-07-22T14:25:43Z",
+    balance: {
+      // 4 / 20 = 20% remaining — above critical (10%) but at/below low (25%),
+      // so checkQuotas emits a `warning`-level notify.
+      credits_remaining_usd: 4,
+      total_credits_usd: 20,
+      credits_used_usd: 16,
+      accounting_method: "token",
+    },
+    usage: {
+      lifetime: { cost_usd: 0, requests: 0, tokens: 0, energy_kwh: 0 },
+      current_month: { cost_usd: 0, requests: 0, tokens: 0, energy_kwh: 0 },
+    },
+    limits: { overage_limit_usd: null, rate_limit_tier: "standard" },
+    subscription: null,
+    key: { name: "test", allowance: null },
+  };
+}
+
+/** Minimal fake ExtensionAPI recording every `pi.on` registration. */
+interface FakePi {
+  pi: ExtensionAPI;
+  /** lifecycle handlers captured by `pi.on(event, handler)` */
+  handlers: Map<string, ((event: unknown, ctx: ExtensionContext) => unknown)[]>;
+  /** every `pi.on` event name, in registration order */
+  onCalls: string[];
+  /** generic event bus: channel -> handlers, with real unsubscribe semantics */
+  emit(channel: string, data: unknown): void;
+}
+
+function fakePi(): FakePi {
+  const handlers = new Map<
+    string,
+    ((event: unknown, ctx: ExtensionContext) => unknown)[]
+  >();
+  const onCalls: string[] = [];
+  const channels = new Map<string, Set<(data: unknown) => void>>();
+  // reset stale ctx via no-op session flags before re-firing.
+  const pi = {
+    on(
+      event: string,
+      handler: (event: unknown, ctx: ExtensionContext) => unknown,
+    ) {
+      onCalls.push(event);
+      const list = handlers.get(event) ?? [];
+      list.push(handler);
+      handlers.set(event, list);
+    },
+    events: {
+      on(channel: string, handler: (data: unknown) => void) {
+        let set = channels.get(channel);
+        if (!set) {
+          set = new Set();
+          channels.set(channel, set);
+        }
+        set.add(handler);
+        return () => {
+          set?.delete(handler);
+        };
+      },
+      emit(channel: string, data: unknown) {
+        const set = channels.get(channel);
+        if (!set) return;
+        for (const h of set) h(data);
+      },
+    },
+  } as unknown as ExtensionAPI;
+
+  const emit = (channel: string, data: unknown) =>
+    pi.events.emit(channel, data);
+
+  const fake: FakePi = { pi, handlers, onCalls, emit };
+  return fake;
+}
+
+async function loadFactory(pi: ExtensionAPI): Promise<void> {
+  await factory(pi);
+}
+
+function emitQuotas(pi: FakePi, quotas: NeuralwattQuotas): void {
+  pi.emit(NEURALWATT_QUOTAS_UPDATED_EVENT, { quotas, source: "header" });
+}
+
+function startSession(pi: FakePi, ctx: ExtensionContext): void {
+  for (const h of pi.handlers.get("session_start") ?? [])
+    h({ type: "session_start", reason: "new" }, ctx);
+}
+
+function shutdownSession(pi: FakePi): void {
+  for (const h of pi.handlers.get("session_shutdown") ?? [])
+    h({ type: "session_shutdown", reason: "quit" }, {} as ExtensionContext);
+}
+
+function selectModel(pi: FakePi, ctx: ExtensionContext): void {
+  for (const h of pi.handlers.get("model_select") ?? [])
+    h(
+      {
+        type: "model_select",
+        model: {},
+        previousModel: undefined,
+        source: "set",
+      },
+      ctx,
+    );
+}
+
+describe("quota-warnings extension (stale-ctx guard)", () => {
+  beforeEach(() => {
+    clearAlertState();
+  });
+
+  it("delivers quota updates to the active session's ctx", async () => {
+    const pi = fakePi();
+    await loadFactory(pi.pi);
+    const ctx = fakeCtx("neuralwatt");
+
+    startSession(pi, ctx);
+    emitQuotas(pi, lowQuotas());
+
+    expect(ctx.calls).toHaveLength(1);
+    expect(ctx.calls[0].level).toBe("warning");
+    expect(ctx.calls[0].msg).toContain("Credits:");
+    expect(ctx.calls[0].msg).toContain("20%");
+  });
+
+  it("does not dereference a stale ctx after session replacement", async () => {
+    const pi = fakePi();
+    await loadFactory(pi.pi);
+    const ctx1 = fakeCtx("neuralwatt");
+    const ctx2 = fakeCtx("neuralwatt");
+
+    startSession(pi, ctx1);
+    // Real Pi ordering: session replacement supersedes ctx1, then the new
+    // session's `session_start` fires — the fix unsubscribes ctx1's listener
+    // before any quota event can deliver to it.
+    startSession(pi, ctx2);
+    ctx1.__deactivate();
+    emitQuotas(pi, lowQuotas());
+
+    expect(ctx1.calls).toHaveLength(0);
+    // The active session's listener still delivers the warning.
+    expect(ctx2.calls).toHaveLength(1);
+  });
+
+  it("unsubscribes the quota listener on session_shutdown", async () => {
+    const pi = fakePi();
+    await loadFactory(pi.pi);
+    const ctx = fakeCtx("neuralwatt");
+
+    startSession(pi, ctx);
+    shutdownSession(pi);
+    ctx.__deactivate();
+    emitQuotas(pi, lowQuotas());
+
+    expect(ctx.calls).toHaveLength(0);
+  });
+
+  it("skips quota events when the active provider is not neuralwatt", async () => {
+    const pi = fakePi();
+    await loadFactory(pi.pi);
+    const ctx = fakeCtx("openai");
+
+    startSession(pi, ctx);
+    emitQuotas(pi, lowQuotas());
+
+    expect(ctx.calls).toHaveLength(0);
+  });
+
+  it("model_select does not redirect the quota listener to a new ctx", async () => {
+    const pi = fakePi();
+    await loadFactory(pi.pi);
+    const ctx1 = fakeCtx("neuralwatt");
+    const ctx2 = fakeCtx("neuralwatt");
+
+    startSession(pi, ctx1);
+    selectModel(pi, ctx2);
+    emitQuotas(pi, lowQuotas());
+
+    // The quota listener is bound to the session that started it; model_select
+    // no longer reassigns it. Exactly one notify, on ctx1.
+    expect(ctx1.calls).toHaveLength(1);
+    expect(ctx2.calls).toHaveLength(0);
+    // The fixed factory registers no model_select handler at all.
+    expect(pi.onCalls).not.toContain("model_select");
+  });
+});

--- a/extensions/quota-warnings/index.ts
+++ b/extensions/quota-warnings/index.ts
@@ -1,7 +1,4 @@
-import type {
-  ExtensionAPI,
-  ExtensionContext,
-} from "@earendil-works/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { configLoader } from "../../src/config";
 import {
   NEURALWATT_CONFIG_UPDATED_EVENT,
@@ -17,7 +14,6 @@ export default async function (pi: ExtensionAPI) {
   await configLoader.load();
 
   let enabled = configLoader.getConfig().quotaWarnings.enabled;
-  let currentContext: ExtensionContext | undefined;
 
   // Listen for config changes at runtime
   pi.events.on(NEURALWATT_CONFIG_UPDATED_EVENT, (data: unknown) => {
@@ -29,32 +25,33 @@ export default async function (pi: ExtensionAPI) {
     }
   });
 
-  pi.events.on(NEURALWATT_QUOTAS_UPDATED_EVENT, (data: unknown) => {
-    if (!enabled) return;
-    if (!data || typeof data !== "object") return;
-    if (!currentContext) return;
-    if (currentContext.model?.provider !== "neuralwatt") return;
-
-    const { quotas } = data as NeuralwattQuotasUpdatedPayload;
-    checkQuotas(currentContext, quotas);
-  });
+  // Subscription to quota updates is scoped to the session that owns `ctx`,
+  // so a captured ctx can never be dereferenced after session replacement.
+  let unsubscribeQuotas: (() => void) | undefined;
 
   pi.on("session_start", async (_event, ctx) => {
-    currentContext = ctx;
+    // The previous session's listener (if any) is superseded first.
+    unsubscribeQuotas?.();
+    unsubscribeQuotas = pi.events.on(
+      NEURALWATT_QUOTAS_UPDATED_EVENT,
+      (data: unknown) => {
+        if (!enabled) return;
+        if (!data || typeof data !== "object") return;
+        // ctx is the active session's context; `.model` is a dynamic getter.
+        if (ctx.model?.provider !== "neuralwatt") return;
+
+        const { quotas } = data as NeuralwattQuotasUpdatedPayload;
+        checkQuotas(ctx, quotas);
+      },
+    );
+
     if (ctx.model?.provider !== "neuralwatt") return;
     clearAlertState();
   });
 
-  pi.on("model_select", (_event, ctx) => {
-    currentContext = ctx;
-  });
-
-  pi.on("session_before_switch", (_event, ctx) => {
-    currentContext = ctx;
-  });
-
   pi.on("session_shutdown", () => {
-    currentContext = undefined;
+    unsubscribeQuotas?.();
+    unsubscribeQuotas = undefined;
     clearAlertState();
   });
 

--- a/extensions/quota-warnings/index.ts
+++ b/extensions/quota-warnings/index.ts
@@ -8,6 +8,7 @@ import {
   type NeuralwattConfigUpdatedPayload,
   type NeuralwattQuotasUpdatedPayload,
 } from "../../src/events";
+import { isStaleExtensionCtxError } from "../_shared/stale-ctx";
 import { checkQuotas, clearAlertState } from "./notifier";
 
 export default async function (pi: ExtensionAPI) {
@@ -25,33 +26,54 @@ export default async function (pi: ExtensionAPI) {
     }
   });
 
-  // Subscription to quota updates is scoped to the session that owns `ctx`,
-  // so a captured ctx can never be dereferenced after session replacement.
-  let unsubscribeQuotas: (() => void) | undefined;
+  // Each session registers its own listener on its own event bus. We track
+  // unsubs in a set rather than a single slot because in-process subagents
+  // (e.g. @gotgenes/pi-subagents) load the same extension module for a sibling
+  // session: a single shared variable would let the child's session_start
+  // clobber (and unsubscribe) the parent's still-live listener. Each session's
+  // bus is separate, so leaving the previous listener in place is safe; real
+  // session replacement fires session_shutdown (below) to clean up, and a
+  // subagent's listener self-cleans when its ctx goes stale (see the catch
+  // below — its dispose() does not emit session_shutdown).
+  const quotaUnsubs = new Set<() => void>();
+  function clearQuotaListeners(): void {
+    for (const unsub of quotaUnsubs) unsub();
+    quotaUnsubs.clear();
+  }
 
   pi.on("session_start", async (_event, ctx) => {
-    // The previous session's listener (if any) is superseded first.
-    unsubscribeQuotas?.();
-    unsubscribeQuotas = pi.events.on(
+    const unsub = pi.events.on(
       NEURALWATT_QUOTAS_UPDATED_EVENT,
       (data: unknown) => {
         if (!enabled) return;
         if (!data || typeof data !== "object") return;
-        // ctx is the active session's context; `.model` is a dynamic getter.
-        if (ctx.model?.provider !== "neuralwatt") return;
+        try {
+          if (ctx.model?.provider !== "neuralwatt") return;
 
-        const { quotas } = data as NeuralwattQuotasUpdatedPayload;
-        checkQuotas(ctx, quotas);
+          const { quotas } = data as NeuralwattQuotasUpdatedPayload;
+          checkQuotas(ctx, quotas);
+        } catch (err) {
+          // ctx was invalidated (owning session disposed, e.g. an in-process
+          // subagent tearing down while its async SSE quota reader still drains).
+          // Stop listening on behalf of this dead session; further updates are
+          // meaningless once its UI is gone.
+          if (isStaleExtensionCtxError(err)) {
+            unsub();
+            quotaUnsubs.delete(unsub);
+          } else {
+            throw err;
+          }
+        }
       },
     );
+    quotaUnsubs.add(unsub);
 
     if (ctx.model?.provider !== "neuralwatt") return;
     clearAlertState();
   });
 
   pi.on("session_shutdown", () => {
-    unsubscribeQuotas?.();
-    unsubscribeQuotas = undefined;
+    clearQuotaListeners();
     clearAlertState();
   });
 

--- a/extensions/sub-bar-integration/index.ts
+++ b/extensions/sub-bar-integration/index.ts
@@ -19,6 +19,7 @@ import {
   percentEnergyRemaining,
 } from "../../src/utils/quota-bar";
 import { formatKwh, formatUsd } from "../../src/utils/quota-format";
+import { isStaleExtensionCtxError } from "../_shared/stale-ctx";
 import { toUsageSnapshot } from "./snapshot";
 
 function formatStatus(quotas: NeuralwattQuotas, theme: Theme): string {
@@ -84,26 +85,49 @@ export default async function (pi: ExtensionAPI) {
     subCoreReady = true;
   });
 
-  // Subscription to quota updates is scoped to the session that owns `ctx`,
-  // so a captured ctx can never be dereferenced after session replacement.
-  let unsubscribeQuotas: (() => void) | undefined;
+  // Each session registers its own listener on its own event bus. We track
+  // unsubs in a set rather than a single slot because in-process subagents
+  // (e.g. @gotgenes/pi-subagents) load the same extension module for a sibling
+  // session: a single shared variable would let the child's session_start
+  // clobber (and unsubscribe) the parent's still-live listener. Each session's
+  // bus is separate, so leaving the previous listener in place is safe; real
+  // session replacement fires session_shutdown (below) to clean up, and a
+  // subagent's listener self-cleans when its ctx goes stale (see the catch
+  // below — its dispose() does not emit session_shutdown).
+  const quotaUnsubs = new Set<() => void>();
+  function clearQuotaListeners(): void {
+    for (const unsub of quotaUnsubs) unsub();
+    quotaUnsubs.clear();
+  }
 
   pi.on("session_start", async (_event, ctx) => {
-    // The previous session's listener (if any) is superseded first.
-    unsubscribeQuotas?.();
-    unsubscribeQuotas = pi.events.on(
+    const unsub = pi.events.on(
       NEURALWATT_QUOTAS_UPDATED_EVENT,
       (data: unknown) => {
-        if (!isActive(ctx) || !subCoreReady || !enabled) return;
+        if (!subCoreReady || !enabled) return;
         if (!data || typeof data !== "object") return;
-        const { quotas } = data as NeuralwattQuotasUpdatedPayload;
-        emitUsage(quotas);
-        ctx.ui.setStatus(
-          "neuralwatt-usage",
-          formatStatus(quotas, ctx.ui.theme),
-        );
+        try {
+          if (!isActive(ctx)) return;
+          const { quotas } = data as NeuralwattQuotasUpdatedPayload;
+          emitUsage(quotas);
+          ctx.ui.setStatus(
+            "neuralwatt-usage",
+            formatStatus(quotas, ctx.ui.theme),
+          );
+        } catch (err) {
+          // ctx was invalidated (owning session disposed, e.g. an in-process
+          // subagent tearing down while its async SSE quota reader still drains).
+          // Stop listening on behalf of this dead session.
+          if (isStaleExtensionCtxError(err)) {
+            unsub();
+            quotaUnsubs.delete(unsub);
+          } else {
+            throw err;
+          }
+        }
       },
     );
+    quotaUnsubs.add(unsub);
 
     if (subCoreReady && isActive(ctx) && enabled) {
       requestQuotas();
@@ -117,8 +141,7 @@ export default async function (pi: ExtensionAPI) {
   });
 
   pi.on("session_shutdown", () => {
-    unsubscribeQuotas?.();
-    unsubscribeQuotas = undefined;
+    clearQuotaListeners();
   });
 
   pi.events.on(NEURALWATT_EXTENSIONS_REQUEST_EVENT, () => {

--- a/extensions/sub-bar-integration/index.ts
+++ b/extensions/sub-bar-integration/index.ts
@@ -56,8 +56,6 @@ export default async function (pi: ExtensionAPI) {
 
   let enabled = configLoader.getConfig().subBarIntegration.enabled;
   let subCoreReady = false;
-  let currentProvider: string | undefined;
-  let currentContext: ExtensionContext | undefined;
 
   // Listen for config changes at runtime
   pi.events.on(NEURALWATT_CONFIG_UPDATED_EVENT, (data: unknown) => {
@@ -65,8 +63,8 @@ export default async function (pi: ExtensionAPI) {
       .enabled;
   });
 
-  function isActive(): boolean {
-    return currentProvider === "neuralwatt";
+  function isActive(ctx: ExtensionContext): boolean {
+    return ctx.model?.provider === "neuralwatt";
   }
 
   function emitUsage(quotas: NeuralwattQuotas): void {
@@ -82,41 +80,45 @@ export default async function (pi: ExtensionAPI) {
     pi.events.emit(NEURALWATT_QUOTAS_REQUEST_EVENT, undefined);
   }
 
-  pi.events.on(NEURALWATT_QUOTAS_UPDATED_EVENT, (data: unknown) => {
-    if (!isActive() || !subCoreReady || !enabled) return;
-    if (!data || typeof data !== "object") return;
-    const { quotas } = data as NeuralwattQuotasUpdatedPayload;
-    emitUsage(quotas);
-
-    if (currentContext) {
-      currentContext.ui.setStatus(
-        "neuralwatt-usage",
-        formatStatus(quotas, currentContext.ui.theme),
-      );
-    }
-  });
-
   pi.events.on("sub-core:ready", () => {
     subCoreReady = true;
   });
 
+  // Subscription to quota updates is scoped to the session that owns `ctx`,
+  // so a captured ctx can never be dereferenced after session replacement.
+  let unsubscribeQuotas: (() => void) | undefined;
+
   pi.on("session_start", async (_event, ctx) => {
-    currentProvider = ctx.model?.provider;
-    currentContext = ctx;
+    // The previous session's listener (if any) is superseded first.
+    unsubscribeQuotas?.();
+    unsubscribeQuotas = pi.events.on(
+      NEURALWATT_QUOTAS_UPDATED_EVENT,
+      (data: unknown) => {
+        if (!isActive(ctx) || !subCoreReady || !enabled) return;
+        if (!data || typeof data !== "object") return;
+        const { quotas } = data as NeuralwattQuotasUpdatedPayload;
+        emitUsage(quotas);
+        ctx.ui.setStatus(
+          "neuralwatt-usage",
+          formatStatus(quotas, ctx.ui.theme),
+        );
+      },
+    );
+
+    if (subCoreReady && isActive(ctx) && enabled) {
+      requestQuotas();
+    }
   });
 
   pi.on("model_select", async (_event, ctx) => {
-    currentProvider = ctx.model?.provider;
-    currentContext = ctx;
-
-    if (subCoreReady && isActive() && enabled) {
+    if (subCoreReady && isActive(ctx) && enabled) {
       requestQuotas();
     }
   });
 
   pi.on("session_shutdown", () => {
-    currentProvider = undefined;
-    currentContext = undefined;
+    unsubscribeQuotas?.();
+    unsubscribeQuotas = undefined;
   });
 
   pi.events.on(NEURALWATT_EXTENSIONS_REQUEST_EVENT, () => {


### PR DESCRIPTION
## Manual verification

I did a symlink from the pi agents neuralwatt extension to my local branch and then tested the same flows that were giving me the error. And now It was not giving me any error. Nevertheless I have never got the quota warning, so I'm not sure how to test that. 

## Summary

- Scope the `neuralwatt:quotas:updated` listener to the active session in `quota-warnings` and `sub-bar-integration`, fixing the stale-ctx crash after session replacement.
- Register the `pi.events.on(NEURALWATT_QUOTAS_UPDATED_EVENT, ...)` subscription inside `pi.on("session_start")` using the fresh `ctx`, store the returned unsubscribe function, and call it on supersession (the next `session_start`) and on `session_shutdown`. A stale ctx's listener is now gone before any throttled quota event can deliver to it.
- Remove the module-level `currentContext` capture and the `model_select`/`session_before_switch` handlers that only re-captured it. `ctx.model` is a dynamic getter on the session ctx, so the session-scoped listener already sees the current model.
- Add `extensions/quota-warnings/index.test.ts` with regression tests pinning the session-scoped contract.

Fixes #53.

## Root cause

The `Event handler error (neuralwatt:quotas:updated): Error: This extension ctx is stale…` stack traces come from the `neuralwatt:quotas:updated` listeners in `quota-warnings` and `sub-bar-integration` dereferencing a stale `ExtensionContext`. The trigger is specifically **in-process subagents** — verified down to the lines in Pi's internals (`agent-session.js`, `extensions/loader.js`, `extensions/runner.js`). Three compounding facts:

1. **pi-subagents runs in-process.** `create-subagent-session.ts` spins up a sibling `AgentSession` in the same process and calls `session.bindExtensions({})`, which fires a fresh `session_start` against the cached extension module.

2. **Extension module state is shared across sessions.** `loadExtensionsCached` caches the extension *factory* by cwd, so the parent and the child reuse the same module-level variables (`unsubscribeQuotas`). Each session gets its **own** `Extension` object and event bus, but the factory closure's module state (the single unsub slot) is shared.

3. **Subagent `dispose()` invalidates the runner but does NOT emit `session_shutdown`.** `AgentSession.dispose()` calls `runner.invalidate(...)` (so any captured child `ctx` throws on access) but never fires `session_shutdown` — so the quota listeners a child registered in its `session_start` are never cleaned up through the normal scoping path.

This produced two bugs:

- **(A) The noisy error.** The SSE quota tee reader (`readQuotaCommentsFromTee`) keeps draining buffered `: energy` / `: cost` comments *after* `dispose()`. Each emit reaches the child's `neuralwatt:quotas:updated` listener, which dereferences the now-invalidated child `ctx` → `assertActive()` throws → Pi logs it as `Event handler error (neuralwatt:quotas:updated)`.
- **(B) Parent loses quota tracking after any subagent run.** The child's `session_start` ran `unsubscribeQuotas?.()` on the shared single slot, which held the **parent's** unsubscribe — removing the parent's listener from the parent's bus. After the subagent returned, the parent got no quota updates until a real session replacement.

The earlier root-cause note ("Pi always emits `session_shutdown` before invalidating the ctx; scoping the listener's lifetime to `[session_start, session_shutdown]` is sufficient") holds for the four documented session-replacement paths (`newSession`/`fork`/`switchSession`/`reload`) but is **incorrect for the in-process subagent path**: `dispose()` is a fifth teardown that invalidates the ctx without the `session_shutdown` the scoping assumed — and, because of fact #2, the shared single-slot unsub let the child clobber the parent's listener along the way.

The fix tracks unsubs in a `Set` (so a child `session_start` cannot remove the parent's listener; each session's bus is separate so coexistence is safe) and wraps `ctx` access in a `try/catch` that, on a stale-ctx error, self-unsubscribes the dead session's listener instead of throwing — real session replacement still cleans up via `session_shutdown`.

## Verification

- `pnpm typecheck`
- `pnpm lint`
- `pnpm format`
- `pnpm test` (76 passed: 71 existing + 5 new)


### Test evidence (red → green)

The genuine differentiator is the `model_select` slice — confirmed red against `3cdf49c` (pre-fix) and green against the fix:

| Slice | Pre-fix | Fix |
| --- | --- | --- |
| delivers quota updates to the active session's ctx | ✓ (guard) | ✓ |
| does not dereference a stale ctx after session replacement | ✓ (guard) | ✓ |
| unsubscribes the quota listener on `session_shutdown` | ✓ (guard) | ✓ |
| skips quota events when the active provider is not neuralwatt | ✓ (guard) | ✓ |
| `model_select` does not redirect the quota listener to a new ctx | ✗ (`expected length 1, got 0`) | ✓ |

\#5 going red on pre-fix proves the test exercises the removed code path (the `currentContext = ctx` reassignment in `model_select`/`session_before_switch`). The remaining slices are regression guards pinning the contract.
