### PR TITLE
chore: add sandbox setup and resume hooks

### DIFF
--- a/.agents/resume
+++ b/.agents/resume
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+git fetch --all --prune --quiet || true
+upstream="$(git rev-parse --abbrev-ref --symbolic-full-name '@{u}' 2>/dev/null || true)"
+if [ -n "$upstream" ] \
+  && [ -z "$(git status --porcelain --untracked-files=no)" ] \
+  && git merge-base --is-ancestor HEAD "$upstream" 2>/dev/null \
+  && [ "$(git rev-list --count "..$upstream")" -gt 0 ]; then
+  git merge --ff-only "$upstream" --quiet || true
+fi
+
+./.agents/setup

--- a/.agents/setup
+++ b/.agents/setup
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+if [ ! -f .envrc ]; then
+  printf 'use nix\n' > .envrc
+fi
+direnv allow
+
+direnv exec . pnpm install


### PR DESCRIPTION
Adds the `.agents/setup` / `.agents/resume` lifecycle hooks run by the homelab sandbox platform when a sandbox is created for this repo.

- `.agents/setup` (once per workspace): creates `.envrc` with `use nix` if missing, allows and reloads direnv, then runs `pnpm install`.
- `.agents/resume` (every boot): fetches all remotes, fast-forwards the current branch when it is strictly behind its upstream, then re-runs setup.

Both hooks are idempotent. The git steps in resume are best-effort so they can never fail the boot.